### PR TITLE
#Update notebooks

### DIFF
--- a/notebooks/getting_started.ipynb
+++ b/notebooks/getting_started.ipynb
@@ -34,10 +34,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 1,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from openfisca_france import FranceTaxBenefitSystem"
@@ -52,10 +50,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 2,
+   "metadata": {},
    "outputs": [],
    "source": [
     "tax_benefit_system = FranceTaxBenefitSystem()"
@@ -70,9 +66,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 3,
    "metadata": {
-    "collapsed": false,
     "scrolled": false
    },
    "outputs": [],
@@ -90,18 +85,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 4,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<openfisca_france.scenarios.Scenario at 0x7f0bb50eb290>"
+       "<openfisca_france.scenarios.Scenario at 0x10d1e9b00>"
       ]
      },
-     "execution_count": 82,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -129,10 +122,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 5,
+   "metadata": {},
    "outputs": [],
    "source": [
     "simulation = scenario.new_simulation()"
@@ -147,18 +138,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([ 129.99000549], dtype=float32)"
+       "array([129.99], dtype=float32)"
       ]
      },
-     "execution_count": 84,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -191,10 +180,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 7,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from openfisca_france.reforms import landais_piketty_saez"
@@ -209,10 +196,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 8,
+   "metadata": {},
    "outputs": [],
    "source": [
     "reform = landais_piketty_saez.landais_piketty_saez(tax_benefit_system)"
@@ -227,10 +212,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 9,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def init_profile(scenario):\n",
@@ -253,18 +236,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 10,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([ 15614.34863281], dtype=float32)"
+       "array([13554.031], dtype=float32)"
       ]
      },
-     "execution_count": 88,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -277,7 +258,7 @@
     "reform_simulation = reform_scenario.new_simulation() \n",
     "\n",
     "# Choose the variable you want to calcul : here the disposable income, \"revdisp\"\n",
-    "reform_simulation.calculate('revdisp', '2013')"
+    "reform_simulation.calculate('revenu_disponible', '2013')"
    ]
   },
   {
@@ -289,18 +270,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 11,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([ 36039.1875], dtype=float32)"
+       "array([33978.87], dtype=float32)"
       ]
      },
-     "execution_count": 89,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -313,7 +292,7 @@
     "reference_simulation = reference_scenario.new_simulation()\n",
     "\n",
     "# Choose the variable you want to calcul\n",
-    "reference_simulation.calculate('revdisp', '2013')"
+    "reference_simulation.calculate('revenu_disponible', '2013')"
    ]
   },
   {
@@ -327,31 +306,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 12,
    "metadata": {
-    "collapsed": false,
     "scrolled": true
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "http://www.openfisca.fr/tools/trace?api_url=http%3A%2F%2Fapi.openfisca.fr&simulation=%7B%22scenarios%22%3A+%5B%7B%22period%22%3A+%222015%22%2C+%22test_case%22%3A+%7B%22familles%22%3A+%5B%7B%22id%22%3A+0%2C+%22parents%22%3A+%5B%22ind0%22%5D%2C+%22enfants%22%3A+%5B%22ind2%22%2C+%22ind3%22%5D%7D%5D%2C+%22foyers_fiscaux%22%3A+%5B%7B%22id%22%3A+0%2C+%22declarants%22%3A+%5B%22ind0%22%5D%2C+%22personnes_a_charge%22%3A+%5B%22ind2%22%2C+%22ind3%22%5D%7D%5D%2C+%22individus%22%3A+%5B%7B%22id%22%3A+%22ind0%22%2C+%22age%22%3A+30%2C+%22salaire_de_base%22%3A+20000.0%7D%2C+%7B%22id%22%3A+%22ind2%22%2C+%22age%22%3A+12%7D%2C+%7B%22id%22%3A+%22ind3%22%2C+%22age%22%3A+18%7D%5D%2C+%22menages%22%3A+%5B%7B%22id%22%3A+0%2C+%22personne_de_reference%22%3A+%22ind0%22%2C+%22enfants%22%3A+%5B%22ind2%22%2C+%22ind3%22%5D%7D%5D%7D%7D%5D%2C+%22variables%22%3A+%5B%22irpp%22%5D%7D\n"
+     "ename": "AttributeError",
+     "evalue": "module 'urllib' has no attribute 'urlencode'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-12-c809734e760c>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mopenfisca_core\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mtools\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m print(tools.get_trace_tool_link(scenario, variables = ['irpp'],\n\u001b[0;32m----> 3\u001b[0;31m                                 api_url = 'http://api.openfisca.fr', trace_tool_url =  'http://www.openfisca.fr/tools/trace'))\n\u001b[0m",
+      "\u001b[0;32m~/.local/share/virtualenvs/Python_3_7_0/lib/python3.7/site-packages/openfisca_core/tools/__init__.py\u001b[0m in \u001b[0;36mget_trace_tool_link\u001b[0;34m(scenario, variables, api_url, trace_tool_url)\u001b[0m\n\u001b[1;32m     75\u001b[0m         \u001b[0;34m'variables'\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mvariables\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     76\u001b[0m         }\n\u001b[0;32m---> 77\u001b[0;31m     url = trace_tool_url + '?' + urllib.urlencode({\n\u001b[0m\u001b[1;32m     78\u001b[0m         \u001b[0;34m'simulation'\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mjson\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdumps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msimulation_json\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     79\u001b[0m         \u001b[0;34m'api_url'\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mapi_url\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAttributeError\u001b[0m: module 'urllib' has no attribute 'urlencode'"
      ]
     }
    ],
    "source": [
     "from openfisca_core import tools\n",
-    "print(tools.get_trace_tool_link(scenario, variables = ['irpp'], api_url = 'http://api.openfisca.fr', trace_tool_url =  'http://www.openfisca.fr/tools/trace'))"
+    "print(tools.get_trace_tool_link(scenario, variables = ['irpp'],\n",
+    "                                api_url = 'http://api.openfisca.fr', trace_tool_url =  'http://www.openfisca.fr/tools/trace'))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 13,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -370,27 +352,34 @@
     "%%javascript\n",
     "$.getScript('https://kmahelona.github.io/ipython_notebook_goodies/ipython_notebook_toc.js')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.9"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-2.7
+python-3.7.O


### PR DESCRIPTION
### See changes in notebooks by looking at diffs with nbdime:
getting-started:  https://gistpreview.github.io/?e649c81dd4230a759968e369019562aa
How-to-handle-axes : https://gistpreview.github.io/?e39e2f72a01b07fdd237ab1aa1984e2e
How-to-handle-periods: https://gistpreview.github.io/?1e3901c54311d877e86bd89366d17d7b






#### Modification on all notebooks
- Runned with Python 3.7.0
- add parenthesis around prints
- correct formulas names (revdisp to revenu_disponible)
- correct calculate to calculate_add for monthly variables with a yearly call
- add periods when it was implicitely passed trhough simulation year (simulation.calculate('csg',))


- add xlim ylim to "how_to_handle_axes.ipynb" graphs

## how_to_handle_periods.ipynb
- add a try except for fomulas called on the wrong period
- Suppress cells [7] about default period since it must now be put explicitely to each calculate call
- suppress the part about stored in cache variables (do not work anymore)
- correct periods.period("month:2015-04:3") TO periods.period('month', '2015-04', 4)
- add link to period documentation

## Runtime.txt
- Switch to python 3.7.0