### PR TITLE
Add script to test notebooks

### DIFF
--- a/notebooks/Makefile
+++ b/notebooks/Makefile
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+all: test
+
+install:
+	pip install -r requirements.txt
+
+test: clean
+	python test_notebooks.py .
+
+clean:
+	rm executed_*

--- a/notebooks/Makefile
+++ b/notebooks/Makefile
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 all: test
 
 install:
@@ -9,4 +7,4 @@ test: clean
 	python test_notebooks.py .
 
 clean:
-	rm executed_*
+	rm -f executed_*

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,36 @@
+# Tutorial Notebooks
+
+## How to test all notebooks
+
+In your console, run:
+
+```
+make install
+make test
+```
+
+If all goes according to plan, you should see a nice `OK` without any ceremonial message 😃
+
+Otherwise, you'll receive really handy feedback telling you where it doesn't work, and why:
+
+```
+---------------------------------------------------------------------------
+<ipython-input-2-6c6f6a2075ab> in <module>()
+----> 1 simulation.calculate('af', '2015')
+
+/Users/hyperion/.pyenv/versions/tutoriel/lib/python2.7/site-packages/openfisca_core/simulations.pyc in calculate(self, variable_name, period, **parameters)
+    153             self.tracer.record_calculation_start(variable.name, period, **parameters)
+    154
+--> 155         self._check_period_consistency(period, variable)
+    156
+    157         extra_params = parameters.get('extra_params', ())
+
+/Users/hyperion/.pyenv/versions/tutoriel/lib/python2.7/site-packages/openfisca_core/simulations.pyc in _check_period_consistency(self, period, variable)
+    288                 variable.name,
+    289                 period
+--> 290                 ).encode('utf-8'))
+    291
+    292         if variable.definition_period == periods.YEAR and period.unit != periods.YEAR:
+
+ValueError: Unable to compute variable 'af' for period 2015: 'af' must be computed for a whole month. You can use the ADD option to sum 'af' over the requested period, or change the requested period to 'period.first_month'.
+```

--- a/notebooks/executed_how_to_handle_periods.ipynb
+++ b/notebooks/executed_how_to_handle_periods.ipynb
@@ -1,0 +1,1063 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<h1 id=\"tocheading\">Table of Contents</h1>\n",
+    "<div id=\"toc\"></div>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Importance of giving a convenient period"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook aim to show easily how periods work in OpenFisca.   "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We need to initialize a **simulation**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from openfisca_france import FranceTaxBenefitSystem\n",
+    "tax_benefit_system = FranceTaxBenefitSystem()\n",
+    "scenario = tax_benefit_system.new_scenario()\n",
+    "scenario.init_single_entity(\n",
+    "    period = 2015,\n",
+    "    parent1 = dict(\n",
+    "        age = 30,\n",
+    "        salaire_de_base = 50000,\n",
+    "        ),\n",
+    "    enfants = [\n",
+    "        dict(age = 12),\n",
+    "        dict(age = 18),\n",
+    "        ],\n",
+    "    )\n",
+    "simulation = scenario.new_simulation()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A simulation's variable is calculated for a specific period.   \n",
+    "This specific time interval have to be given when calling a variable to avoid computation problem.\n",
+    "\n",
+    "### Variables with monthly formulas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Some variables are computed over the month.   \n",
+    "For exemple the variable  `allocation familiales`.  \n",
+    "If called on an annual basis, an error is displayed : "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "Unable to compute variable 'af' for period 2015: 'af' must be computed for a whole month. You can use the ADD option to sum 'af' over the requested period, or change the requested period to 'period.first_month'.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-2-6c6f6a2075ab>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0msimulation\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcalculate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'af'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'2015'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/Users/hyperion/.pyenv/versions/tutoriel/lib/python2.7/site-packages/openfisca_core/simulations.pyc\u001b[0m in \u001b[0;36mcalculate\u001b[0;34m(self, variable_name, period, **parameters)\u001b[0m\n\u001b[1;32m    153\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtracer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrecord_calculation_start\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mparameters\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    154\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 155\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_check_period_consistency\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvariable\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    156\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    157\u001b[0m         \u001b[0mextra_params\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mparameters\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'extra_params'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/hyperion/.pyenv/versions/tutoriel/lib/python2.7/site-packages/openfisca_core/simulations.pyc\u001b[0m in \u001b[0;36m_check_period_consistency\u001b[0;34m(self, period, variable)\u001b[0m\n\u001b[1;32m    288\u001b[0m                 \u001b[0mvariable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    289\u001b[0m                 \u001b[0mperiod\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 290\u001b[0;31m                 ).encode('utf-8'))\n\u001b[0m\u001b[1;32m    291\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    292\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mvariable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefinition_period\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0mperiods\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mYEAR\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0munit\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0mperiods\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mYEAR\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: Unable to compute variable 'af' for period 2015: 'af' must be computed for a whole month. You can use the ADD option to sum 'af' over the requested period, or change the requested period to 'period.first_month'."
+     ]
+    }
+   ],
+   "source": [
+    "simulation.calculate('af', '2015')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This assertion error :    \n",
+    "    \"`Requested period 2015 differs from 2015-01 returned by variable af`\"   \n",
+    "means exactly the fact that `af` are computed for a month, therefore the variable returned value for `2015-01`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But when called on its period (monthly), the result of the variable's formula will be returned"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 129.99000549], dtype=float32)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simulation.calculate('af', '2015-01') #calculate variable af for January 2015"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Variable with annual formulas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Other formulas only works on a annual basis, thus a monthly call will not work, e.g irpp (impôt sur le revenu) :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "Requested period 2015-01 differs from 2015 returned by variable irpp",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0mTraceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-4-c5f820ae8a5c>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0msimulation\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcalculate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'irpp'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'2015-01'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/home/notebook/virtualenvs/openfisca/local/lib/python2.7/site-packages/openfisca_core/simulations.pyc\u001b[0m in \u001b[0;36mcalculate\u001b[0;34m(self, column_name, period, **parameters)\u001b[0m\n\u001b[1;32m     72\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mperiod\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     73\u001b[0m             \u001b[0mperiod\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mperiod\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 74\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcompute\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcolumn_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mparameters\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0marray\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     75\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     76\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mcalculate_add\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcolumn_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mNone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mparameters\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/home/notebook/virtualenvs/openfisca/local/lib/python2.7/site-packages/openfisca_core/simulations.pyc\u001b[0m in \u001b[0;36mcompute\u001b[0;34m(self, column_name, period, **parameters)\u001b[0m\n\u001b[1;32m    157\u001b[0m                 \u001b[0mcaller_input_variables_infos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable_infos\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    158\u001b[0m         \u001b[0mholder\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_or_new_holder\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcolumn_name\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 159\u001b[0;31m         \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mholder\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcompute\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mperiod\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mparameters\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    160\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mprint_trace\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    161\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mprint_trace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariable_name\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcolumn_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mprint_trace_kwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/home/notebook/virtualenvs/openfisca/local/lib/python2.7/site-packages/openfisca_core/holders.pyc\u001b[0m in \u001b[0;36mcompute\u001b[0;34m(self, period, **parameters)\u001b[0m\n\u001b[1;32m    140\u001b[0m                 \u001b[0;32massert\u001b[0m \u001b[0maccept_other_period\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0mformula_dated_holder\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mperiod\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0mperiod\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;31m \u001b[0m\u001b[0;31m\\\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    141\u001b[0m                     \"Requested period {} differs from {} returned by variable {}\".format(period,\n\u001b[0;32m--> 142\u001b[0;31m                         formula_dated_holder.period, column.name)\n\u001b[0m\u001b[1;32m    143\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mformula_dated_holder\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    144\u001b[0m         \u001b[0marray\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mempty\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mentity\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcount\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdtype\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcolumn\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdtype\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAssertionError\u001b[0m: Requested period 2015-01 differs from 2015 returned by variable irpp"
+     ]
+    }
+   ],
+   "source": [
+    "simulation.calculate('irpp', '2015-01')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It must be called on an annual basis :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([-2400.52807617], dtype=float32)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simulation.calculate('irpp', '2015') #calculate variable irpp for 2015"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Default period"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When a variable is called without period, the simulation's default period is used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Period((u'year', Instant((2015, 1, 1)), 1))"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simulation.period"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here default simulation period is a year. Thus the variable `irpp` can be computed but not the variable `af`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[-2400.52807617]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(simulation.calculate('irpp'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this case simulation.calculate('irpp') is equivalent to simulation.calculate('irpp', '2015')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ True]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(simulation.calculate('irpp') == simulation.calculate('irpp', '2015'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**WARNING** : this demonstration shows the necessity of being aware over which kind of period each measure you want to compute is based on.\n",
+    "\n",
+    "### How to know the definition period of a variable\n",
+    "\n",
+    "If you've forgotten over which kind of period (year or month) your variable is defined in the legislation, you may check in the [legislation explorer](https://legislation.openfisca.fr/variables).\n",
+    "\n",
+    "The information is located in the code source.\n",
+    "\n",
+    "Example for the  [irpp](https://legislation.openfisca.fr/variables/irpp), a tax with annual definition, you will find the period at the end of the website page:\n",
+    "\n",
+    "![](irpp_period.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Solutions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Specific period calls insure that no errors are made by the user.  \n",
+    "If a annual based variable is asked to be computed monthly, the software returns an error.\n",
+    "\n",
+    "But there is solutions to get the result of a given variable on another kind of period, a annual based variable over a month for example."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### Calculate_add : small to larger period"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "The calculate_add method has the same behavior as calculate, except that it sum all variables given their instant of calculus over a period lenght."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ 1559.88000488]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print simulation.calculate_add(\"af\", \"2015\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "This result is equivalent to do sum all monthly calculate over the period."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "annual_af = 0 #create annual_af equals to 0\n",
+    "for month in range(1,13): # [1,2,...,11,12]\n",
+    "    annual_af += simulation.calculate(\"af\", '2015-{}'.format(month)) #add recursively af for all month in 2014"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ 1559.88000488]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print annual_af"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We thus see that annual_af is equal to simulation.calculate_add('af', \"2014\").\n",
+    "\n",
+    "We can test that :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ True]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print simulation.calculate_add('af','2015') == annual_af"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Calculate_divide : large to smaller period"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([-200.04400635], dtype=float32)"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simulation.calculate_divide(\"irpp\", \"2015-01\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([-200.04400635], dtype=float32)"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simulation.calculate(\"irpp\", \"2015\")/12"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Be warned, when a variable is calculated on a monthly basis with calculate_divide (or add), the result is stored in cache.\n",
+    "\n",
+    "Now you can do :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([-200.04400635], dtype=float32)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simulation.calculate('irpp', '2015-01')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Calculate_add_divide \n",
+    "Some variables are not constant over the year but you might want it as an average value for each month.\n",
+    "\n",
+    "For exemple variable `'ars'` (allocation de rentrée scolaire), is computed only in september. To smooth it over the year, we must use calculate_add_divide. It will simply sum it over a given period, and then divide it over sub-periods of that period."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 65.20347595], dtype=float32)"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simulation.calculate('ars', '2014')/12"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 49.92318344], dtype=float32)"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simulation.calculate_add_divide('ars', \"2014-08\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Que fait add_divide ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "simulation.compute_add_divide??"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# The Concept of Period"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also use more exotic period by using the class periods.   \n",
+    "\n",
+    "Actually when we do : `simulation.calculate('irpp','2015')`, the '2015' string is converted into an object period.  \n",
+    "\n",
+    "A more explicit way to do this, is :  `simulation.calculate('irpp', periods.period('2015'))`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Period((u'year', Instant((2015, 1, 1)), 1))"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from openfisca_core import periods # OpenFisca_core is the architecture of OpenFisca\n",
+    "periods.period('2015')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[-2400.52807617]\n",
+      "[ True]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(simulation.calculate('irpp', periods.period('2015')))\n",
+    "print(simulation.calculate('irpp', periods.period('2015'))== simulation.calculate('irpp', 2015))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Definition\n",
+    "We can look at periods docstring to understand how it works :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Return a new period, aka a triple (unit, start_instant, size).\n",
+      "\n",
+      "    >>> period(u'2014')\n",
+      "    Period((u'year', Instant((2014, 1, 1)), 1))\n",
+      "    >>> period(u'2014:2')\n",
+      "    Period((u'year', Instant((2014, 1, 1)), 2))\n",
+      "    >>> period(u'2014-2')\n",
+      "    Period((u'month', Instant((2014, 2, 1)),\n"
+     ]
+    }
+   ],
+   "source": [
+    "print periods.period.__doc__[: 280] #periods.period? would also display the help, suppress the brackets to get full doc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A *period* is constituted of three parameters:\n",
+    "- A unit : day, month and year\n",
+    "- A start instant : the date at which it starts\n",
+    "- And a size : the number of unit \n",
+    "\n",
+    "periods.period('day','2014-03-01', 32) would be a period going from the first of March to the first of april"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Computing over several months"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we want to calculate the 'allocation familiales' from the April to July."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ 519.96002197]\n"
+     ]
+    }
+   ],
+   "source": [
+    "af_march_to_july = simulation.calculate_add('af' ,periods.period('month', '2015-04', 4))\n",
+    "print af_march_to_july"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A simplificated version of period declaration exists with the symbol: `\":\"`.\n",
+    "\n",
+    "`year-month:n` means n months beginning at the month, year.\n",
+    "\n",
+    "Example with `af_march_to_july`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ 519.96002197]\n"
+     ]
+    }
+   ],
+   "source": [
+    "af_march_to_july = simulation.calculate_add('af' ,'2015-04:4')\n",
+    "print af_march_to_july"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Computing over several years with identique scenario\n",
+    "\n",
+    "Computing over several years needs to rethink how we've declared the scenario:  \n",
+    "the starting scenario has, as `period`, one year, `2015`, so it won't be able to compute anything outside this time interval.\n",
+    "\n",
+    "The idea is to change the period over which the scenario applies, using the syntax shown previously.  \n",
+    "\n",
+    "**WARNING : handling the stretching of values **  \n",
+    "Doing that defines the other variables for the entire time interval including their values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#we have to give a new scenario\n",
+    "scenario_over_years = tax_benefit_system.new_scenario()\n",
+    "scenario_over_years.init_single_entity(\n",
+    "    period = '2014:3', # it means three years starting in 2014\n",
+    "    parent1 = dict(\n",
+    "        date_naissance = 1975,\n",
+    "        salaire_de_base = 50000 * 3 , # if we want 50000 for each of the three years\n",
+    "        ),\n",
+    "    enfants = [\n",
+    "        dict(date_naissance = 2001),\n",
+    "        dict(date_naissance = 1999),\n",
+    "        ],\n",
+    "    )\n",
+    "simulation_over_years = scenario_over_years.new_simulation()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**WARNING : handling the age**   \n",
+    "We've changed the variable `age` to `date_naissance` in order that the individuals get older. If we've kept the `age` they would have the same age for the entire period.\n",
+    "\n",
+    "Now we can compute the `irpp` with the function previously used : `calculate_add`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([-4813.68652344], dtype=float32)"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simulation_over_years.calculate_add('irpp', '2014:2') # for 2014 and 2015"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It takes in consideration the legislation change between the two years.    \n",
+    "Therefore it equals the sum of `irpp` for each year but not the double of `irpp` for one year."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[-4813.68652344]\n",
+      "[-4826.31738281]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(simulation_over_years.calculate('irpp', '2015') + simulation_over_years.calculate('irpp', '2014'))\n",
+    "print(simulation_over_years.calculate_add('irpp', '2014')*2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These formulas are still working for variables defined on a monthly basis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 4616.37402344], dtype=float32)"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simulation_over_years.calculate_add('af', '2015:2')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### Computing over several years changing scenario\n",
+    "\n",
+    "You might want to make evolve some given values over the years.\n",
+    "\n",
+    "The tool for it will be to use a Python dictionnary.\n",
+    "\n",
+    "For example, if you want to give a wage evolution :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "scenario_over_years = tax_benefit_system.new_scenario()\n",
+    "scenario_over_years.init_single_entity(\n",
+    "    period = '2014:3',\n",
+    "    parent1 = dict(\n",
+    "        date_naissance = 1975,\n",
+    "        salaire_de_base = {'2014':50000, '2015': 50500, '2016':51000},\n",
+    "        ),\n",
+    "    enfants = [\n",
+    "        dict(date_naissance = 2001),\n",
+    "        dict(date_naissance = 1999),\n",
+    "        ],\n",
+    "    )\n",
+    "simulation_over_years = scenario_over_years.new_simulation()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([-7376.67675781], dtype=float32)"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simulation_over_years.calculate_add('irpp', '2014:3') # for 2014, 2015 and 2016"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "*Command line to get the Notebook's Table of Contents:*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "$.getScript('https://kmahelona.github.io/ipython_notebook_goodies/ipython_notebook_toc.js')"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%javascript\n",
+    "$.getScript('https://kmahelona.github.io/ipython_notebook_goodies/ipython_notebook_toc.js')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/getting_started.ipynb
+++ b/notebooks/getting_started.ipynb
@@ -35,9 +35,7 @@
   {
    "cell_type": "code",
    "execution_count": 79,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from openfisca_france import FranceTaxBenefitSystem"
@@ -53,9 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": 80,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tax_benefit_system = FranceTaxBenefitSystem()"
@@ -72,7 +68,6 @@
    "cell_type": "code",
    "execution_count": 81,
    "metadata": {
-    "collapsed": false,
     "scrolled": false
    },
    "outputs": [],
@@ -91,9 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": 82,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -148,9 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": 84,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -192,9 +183,7 @@
   {
    "cell_type": "code",
    "execution_count": 85,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from openfisca_france.reforms import landais_piketty_saez"
@@ -210,9 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": 86,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "reform = landais_piketty_saez.landais_piketty_saez(tax_benefit_system)"
@@ -254,9 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": 88,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -276,8 +261,8 @@
     "#Simulate the reform\n",
     "reform_simulation = reform_scenario.new_simulation() \n",
     "\n",
-    "# Choose the variable you want to calcul : here the disposable income, \"revdisp\"\n",
-    "reform_simulation.calculate('revdisp', '2013')"
+    "# Choose the variable you want to calcul : here the disposable income, \"revenu_disponible\"\n",
+    "reform_simulation.calculate('revenu_disponible', '2013')"
    ]
   },
   {
@@ -290,9 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": 89,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -313,7 +296,7 @@
     "reference_simulation = reference_scenario.new_simulation()\n",
     "\n",
     "# Choose the variable you want to calcul\n",
-    "reference_simulation.calculate('revdisp', '2013')"
+    "reference_simulation.calculate('revenu_disponible', '2013')"
    ]
   },
   {
@@ -329,7 +312,6 @@
    "cell_type": "code",
    "execution_count": 90,
    "metadata": {
-    "collapsed": false,
     "scrolled": true
    },
    "outputs": [
@@ -349,9 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -374,23 +354,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.9"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/notebooks/how_to_handle_axes.ipynb
+++ b/notebooks/how_to_handle_axes.ipynb
@@ -27,10 +27,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -39,10 +37,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from openfisca_france import FranceTaxBenefitSystem   \n",
@@ -60,10 +56,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "scenario = tax_benefit_system.new_scenario()\n",
@@ -92,98 +86,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([      0.        ,    1010.10101318,    2020.20202637,\n",
-       "          3030.30297852,    4040.40405273,    5050.50488281,\n",
-       "          6060.60595703,    7070.70703125,    8080.80810547,\n",
-       "          9090.90917969,   10101.00976562,   11111.11132812,\n",
-       "         12121.21191406,   13131.31347656,   14141.4140625 ,\n",
-       "         15151.515625  ,   16161.61621094,   17171.71679688,\n",
-       "         18181.81835938,   19191.91992188,   20202.01953125,\n",
-       "         21212.12109375,   22222.22265625,   23232.32226562,\n",
-       "         24242.42382812,   25252.52539062,   26262.62695312,\n",
-       "         27272.7265625 ,   28282.828125  ,   29292.9296875 ,\n",
-       "         30303.03125   ,   31313.13085938,   32323.23242188,\n",
-       "         33333.33203125,   34343.43359375,   35353.53515625,\n",
-       "         36363.63671875,   37373.73828125,   38383.83984375,\n",
-       "         39393.9375    ,   40404.0390625 ,   41414.140625  ,\n",
-       "         42424.2421875 ,   43434.34375   ,   44444.4453125 ,\n",
-       "         45454.546875  ,   46464.64453125,   47474.74609375,\n",
-       "         48484.84765625,   49494.94921875,   50505.05078125,\n",
-       "         51515.15234375,   52525.25390625,   53535.35546875,\n",
-       "         54545.453125  ,   55555.5546875 ,   56565.65625   ,\n",
-       "         57575.7578125 ,   58585.859375  ,   59595.9609375 ,\n",
-       "         60606.0625    ,   61616.16015625,   62626.26171875,\n",
-       "         63636.36328125,   64646.46484375,   65656.5625    ,\n",
-       "         66666.6640625 ,   67676.765625  ,   68686.8671875 ,\n",
-       "         69696.96875   ,   70707.0703125 ,   71717.171875  ,\n",
-       "         72727.2734375 ,   73737.375     ,   74747.4765625 ,\n",
-       "         75757.578125  ,   76767.6796875 ,   77777.78125   ,\n",
-       "         78787.875     ,   79797.9765625 ,   80808.078125  ,\n",
-       "         81818.1796875 ,   82828.28125   ,   83838.3828125 ,\n",
-       "         84848.484375  ,   85858.5859375 ,   86868.6875    ,\n",
-       "         87878.7890625 ,   88888.890625  ,   89898.9921875 ,\n",
-       "         90909.09375   ,   91919.1953125 ,   92929.2890625 ,\n",
-       "         93939.390625  ,   94949.4921875 ,   95959.59375   ,\n",
-       "         96969.6953125 ,   97979.796875  ,   98989.8984375 ,  100000.        ], dtype=float32)"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "simulation.calculate('salaire_de_base', 2014)"
+    "simulation.calculate_add('salaire_de_base', 2014)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "income_tax = - simulation.calculate('irpp', 2014)\n",
-    "gross_wage = simulation.calculate('salaire_de_base', 2014)"
+    "gross_wage = simulation.calculate_add('salaire_de_base', 2014)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.text.Text at 0x7fad84ab3890>"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAaIAAAEPCAYAAAAAicBfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3Xm8XfO9//HXm0hpEaFFCWKeh3JFzIc2iBalRSiJoNTQ\nht6abn8l2t5btC5SMxGJhlAxxJgEOVSaQS4xk6giMcSURKWGDJ/fH9/vke04Jznk7L32Puf9fDzO\nw9rfvdZen7WznM9Z3/Vd348iAjMzs6IsVXQAZmbWvjkRmZlZoZyIzMysUE5EZmZWKCciMzMrlBOR\nmZkVqqyJSNJASTMkPVXStrWkcZKekDRR0vYl7w2QNFXSZEnblLT3kTRF0ouSepe0byvpqfzexeU8\nFjMzK49yXxENAvZu1HYBcE5EfAc4J79G0r7A+hGxIXA8cGVu7wycDWwP7ACcI6lT/qwrgGMjYiNg\nI0mN92VmZlWurIkoIh4FZjZqXgA0JJKVgNfz8v7AkLzdBKCTpNVIiWxURMyOiFnAKGAfSasDK0TE\nxLz9EOCHZTsYMzMriw4F7PNUYKSkCwEBO+X2NYFpJetNz22N218vaZ/exPpmZlZDihiscALQLyLW\nJiWl63K7Gq0nIJpoZzHtZmZWQ4q4IuoTEf0AIuJWSdfm9unAWiXrdQHeyO11jdrHLGL9JklykjIz\n+woioqk//FtNJa6IxOevXl6XtDuApO8CU3P7CKB3bu8OzIqIGcBIoIekTnngQg9gZES8BXwgqZsk\n5W3vXFQgEeGfCM4555zCY6iWH38X/i78XSz6pxLKekUk6UbS1cwqkl4jjZL7KTBA0tLAx8BxABFx\nr6R9Jb0EzAH65vaZkn4HTCJ1vZ0badACwInA9cCywL0RcX85j8fMzFpfWRNRRBzezFv/0cz6JzfT\nfj0p4TRu/z9gy68YnpmZVQHPrNAO1dXVFR1C1fB3sZC/i4X8XVSWKtUHWDRJ0V6O1cystUgi2sBg\nBTMzs2Y5EZmZWaGciMzMrFBORGZmVignIjMzK5QTkZmZFcqJyMzMCuVEZGZmhXIiMjOzJk2btvh1\nWoMTkZmZfcHdd8OOO1ZmX05EZmb2ORMnwtFHw223VWZ/TkRmZvaZl16CAw6A666Dbt0qs08nIjMz\nA+Cdd6BnTzj3XPjBDyq3XyciMzNjzhz4/vehVy847rjK7rusiUjSQEkzJD3VqP3nkl6Q9LSk80ra\nz5I0VdLzkvYqad8nrz9F0hkl7V0ljZf0oqSbJJW10J+ZWVs0b15KQJttBr/9beX3X+4rokHA3qUN\nkuqA/YAtImJL4E+5fVPgEGBToCdwuZKlgEvz52wOHCZpk/xx5wMXRsTGwCzgmDIfj5lZmxIBJ50E\nn34K11wDKmvloaaVNRFFxKPAzEbNJwDnRcS8vM67uf0AYFhEzIuIV4CpQLf8MzUiXo2IucCwvC7A\nnsDwvDwYOLBcx2Jm1hb9/vfw2GNw662wzDLFxFDEPaKNgN1yl9oYSdvl9jWB0senXs9tjdunA2tK\nWgWYGRELStrXKG/oZmZtx4ABMHgw3HMPrLBCcXEUcU+lA7BSRHSXtD3wV2A9oKkLwqDpZBl5/cbb\nLLIWeP/+/T9brqurc116M2u3Bg6ECy+ERx6Bb397YXt9fT319fUVjaWIRDQNuA0gIh6TND9f3UwH\n1i5ZrwvwBinZfKE9It6VtJKkpfJVUcP6zSpNRGZm7dVNN8HZZ8OYMbDOOp9/r/Ef6eeee27Z46lE\n11zjK5c7gO8CSNoI6BgR7wEjgEMldZS0LrABMBF4DNhA0jqSOgK9gDvzZz0EHJyX+5S0m5lZE665\nBk49FUaOhI02KjqapKxXRJJuBOqAVSS9BpwDXAcMkvQ08AnQGyAinpN0C/AcMBc4MSICmC/pZGAU\nKXEOjIgX8i7OBIZJ+h3wBDCwnMdjZlar5s2D//xPuP/+1B1XLUkIQOl3fdsnKdrLsZqZlZo5Ew49\nNA3NHjYMOndu+baSiIiyDur2zApmZm3Yiy9C9+6w6aZpdNyXSUKV4kRkZtZGjRoFu+4Kp50Gl1wC\nHap07pkqDcvMzL6qiPSM0B/+kB5U3W23oiNaNCciM7M25NNP05Q948enn65di45o8ZyIzMzaiHfe\ngR/9CFZeGf7+92JnS/gyfI/IzKwNePrpVMhu111TZdVaSULgKyIzs5p3551w7LFpQMLhhxcdzZfn\nRGRmVqMi0oCEyy+He++F7bcvOqKvxonIzKwGffQRHHMMvPQSTJwIa9Rw7QHfIzIzqzFvvAG7756W\nH364tpMQOBGZmdWUxx6DHXaAAw+EoUNhueWKjmjJuWvOzKxGDBsGP/95mkH7hz8sOprW40RkZlbl\nFixI9YOGDoUHH4Sttio6otblRGRmVsU+/BCOPBLefRcmTIBVVy06otbne0RmZlXq1Vdh551hlVXS\nlVBbTELgRGRmVpUefTSVbzj66HRPqGPHoiMqn7ImIkkDJc2Q9FQT7/1K0gJJK5e0DZA0VdJkSduU\ntPeRNEXSi5J6l7RvK+mp/N7F5TwWM7NKue46OOgguP566NcvFbRry8p9RTQI2Ltxo6QuwPeAV0va\negLrR8SGwPHAlbm9M3A2sD2wA3COpE55syuAYyNiI2AjSV/Yl5lZrZg3D049Fc47L5Xz3rud/EYr\nayKKiEeBmU28dRFwWqO2A4AhebsJQCdJq5ES2aiImB0Rs4BRwD6SVgdWiIiJefshQBsa0Ghm7cms\nWfCDH8Azz6RBCZtsUnRElVPxe0SS9gOmRcTTjd5aE5hW8np6bmvc/npJ+/Qm1jczqylTpqT7QRtv\nDPfdV53lvMuposO3JS0H/Bro0dTbTbyOJtpZTHuz+vfv/9lyXV0ddXV1i1rdzKzsRo+GI46A3/8e\nfvrToqOB+vp66uvrK7pPRSzyd/eS70BaB7grIraStAXwAPBvUiLpQrrC6Qb8FhgTETfn7V4Adgf2\nAOoi4me5/UpgDPBwXn/T3N4L2D0iTmgmjij3sZqZtVQEXHZZSkA337xw7rhqI4mIKOtwiUp0zSn/\nEBHPRMTqEbFeRKxL6k77TkS8DYwAegNI6g7MiogZwEigh6ROeeBCD2BkRLwFfCCpmyTlbe+swPGY\nmS2RTz+FE06Aq66CceOqNwlVSlm75iTdCNQBq0h6DTgnIgaVrPJZF1tE3CtpX0kvAXOAvrl9pqTf\nAZPy+ufmQQsAJwLXA8sC90bE/eU8HjOzJfXuu/DjH8OKK9ZWOe9yKnvXXLVw15yZFe2ZZ2D//eHQ\nQ1OX3NJLFx3R4lWia85zzZmZVcBdd6VCdhddBD/5SdHRVBcnIjOzMoqA88+HSy+Fu++Gbt2Kjqj6\nOBGZmZXJxx/DscfCCy/A+PHQpUvREVUnT3pqZlYGb76ZRsPNnZum63ESap4TkZlZK5s0KXXB7bdf\nqqr69a8XHVF1c9ecmVkruvlmOPlkuPpqOPDAoqOpDU5EZmatYMECOOccuOEGeOAB2HrroiOqHU5E\nZmZL6MMPoXdvePttmDix7VZSLRffIzIzWwKvvgq77AIrrdS2y3mXkxORmdlXNHZsKt9w5JEwcCB8\n7WtFR1Sb3DVnZvYVXHcdnHkmDB4MPXsWHU1tcyIyM/sS5s+H00+HESPg4Ydh002Ljqj2ORGZmbXQ\n7NnQq1d6SHXCBFh55aIjaht8j8jMrAWmTk33gzbYIJXzdhJqPU5EZmaL8eCDaWTcKafAn/8MyyxT\ndERti7vmzMya0bicd11d0RG1TWW9IpI0UNIMSU+VtF0g6XlJkyUNl7RiyXtnSZqa39+rpH0fSS9I\nmiLpjJL2rpLGS3pR0k2SnFjNrFXMnZvKeV95Zaqk6iRUPuXumhsE7N2obRSweURsA0wFzgKQtBlw\nCLAp0BO4XMlSwKX5czYHDpO0Sf6s84ELI2JjYBZwTJmPx8zagXffhR494I03UhJab72iI2rbypqI\nIuJRYGajtgciYkF+OR5omBx9f2BYRMyLiFdISapb/pkaEa9GxFxgGHBA3mZPYHheHgx4ikEzWyLP\nPgs77AA77gi33w4rrrj4bWzJFD1Y4Wjg3ry8JjCt5L3Xc1vj9unAmpJWAWaWJLXpwBrlDdfM2rK7\n74Y99oBzz4U//AGWXrroiNqHwu6pSPo1MDcibmpoamK1oOlkGXn9xtvEovbZv3//z5br6uqoc6ev\nmZEGJfzxj3DJJelB1e7di46oOPX19dTX11d0n4UkIkl9gH1JXWsNpgNrlbzuArxBSjZrN26PiHcl\nrSRpqXxV1LB+s0oTkZkZpHLexx2XuuTGj4e11lr8Nm1Z4z/Szz333LLvsxJdc5+7cpG0D3A6sH9E\nfFKy3gigl6SOktYFNgAmAo8BG0haR1JHoBdwZ97mIeDgvNynpN3MbLHefDN1xX3yCfztb05CRSn3\n8O0bgb8DG0l6TVJf4M/A8sBoSY9LuhwgIp4DbgGeI903OjGS+cDJpNF2z5IGNLyQd3Em8EtJU4CV\ngYHlPB4zazsefzwNSujZ0+W8i6aIRd5WaTMkRXs5VjNbtL/+FU48MT0j9KMfFR1NdZNERDR1D7/V\n+AFQM2s3FixII+Kuvx5Gj4Zttik6IgMnIjNrJ+bMgT590kOqEyfCaqsVHZE1KPo5IjOzsnvttTRp\n6QorwJgxTkLVxonIzNq0cePSLAk/+Umqqupy3tXHXXNm1mYNHgynnZbuCe27b9HRWHNanIgkfa3R\ncz9mZlVp/nw46yy47Taor4fNNis6IluUxXbNSeom6WnSJKRI2lrSn8semZnZV/DBB7D//jBpUirn\n7SRU/Vpyj2gA8APgPYCIeBLYo5xBmZl9Ff/4R5onrmtXGDkSVlml6IisJVqSiJaKiFcbtc0vRzBm\nZl/VmDGw887w85+nqqou5107WnKPaJqkbkBIWhr4OTClvGGZmbXcFVekB1VvvBH23HPx61t1aUki\nOoHUPbc2MAN4ILeZmRVq7lzo1y8NSBg7FtZfv+iI7KvwXHNmVpPeew8OPjhNVnrjja6kWi5VMdec\npLVJs193LV0/Ig4qX1hmZs177rk0Mu7AA+G881xJtda1pGtuBDAEGA0sWMy6ZmZldc890Ldvqqja\np0/R0VhraEki+jQi/rfskZiZLUIEXHgh/O//wp13pml7rG1oyfDtP0v6f5K2l7RVw09LPlzSQEkz\nJD1V0tZZ0ihJL0oaKalTyXsDJE2VNFnSNiXtfSRNydv0LmnfVtJT+b2LW3jMZlZjPv4YjjoKhg5N\n5bydhNqWliSijYCTgIuBy/LPpS38/EHA3o3azgQeiIiNSaW+zwKQ1BNYPyI2BI4HrsztnYGzge2B\nHYBzSpLXFcCxEbERqQps432ZWY17661UznvOHHj0UVh77aIjstbWkkR0GNA1InaOiF3zz24t+fCI\neBSY2aj5AGBwXh6cXze0D8nbTQA6SVqNlMhGRcTsiJhFKhm+j6TVgRUiYmLefgjww5bEZWa14Ykn\nUjnvvfaCW26Bb3yj6IisHFpyj+hZYAWgtSY8XTUiZgBExFuSVs3tawLTStabntsat79e0j69ifXN\nrA249VY44QS4/PI0TNvarpYkohWAFyRNoCQZlWH4duNx6gKiiXYW025mNWzBAvj97+Haa9N8cdtu\nW3REVm4tSUT/3cr7nCFptYiYkbvX3s7t04G1StbrAryR2+satY9ZxPrN6t+//2fLdXV11NXVNbuu\nmVXenDlpUMK0aWnm7G9/u+iI2p/6+nrq6+srus8Wzawg6ZvAf+SXkyLi3RbvQOoK3BURW+bX5wPv\nR8T5ks4EVoqIMyXtC5wUEd+X1B24OCK658EKk4BtSfe0JgHbRcSsfJX2c+Ax4B5gQETc30wcnlnB\nrIpNmwYHHABbbAFXXw3LLlt0RAaVmVmhJfWIfgQ8DhwJ9AYmSTqwJR8u6Ubg76QRba9J6gucB/SQ\n9CLw3fyaiLgX+Kekl4CrgBNz+0zgd6QENAE4Nw9aIK8zkDQJ69TmkpCZVbdx49KghMMOS1VVnYTa\nl8VeEUl6EtirYYBBHsk2KiK2rkB8rcZXRGbVacgQ+NWv4Lrr4Ac/KDoaa6wq5poj1SOaUfL6HVo2\n7NvMrFkN5byHD0+1hDbfvOiIrCgtSUSjJd0L3Jhf9yI9y2Nm9pV88AEcfnganDBxoiuptnct6ZoT\ncDCwC2nI9CPArbXWz+WuObPq8I9/pJmzd9sNBgxwJdVqV4muuZYkorWBdyLio/x6OeCbETFtkRtW\nGScis+KNGZMGJJx9Npx4YtHRWEtUxag54DZgfsnrBcDw8oRjZm3VVVdBr16piJ2TkJVqyT2iDhHx\nacOLiPhE0tfKGJOZtSFz58Kpp8KDD6Zy3htsUHREVm1ackX0Xn7YFABJPwDeL19IZtZWvP8+9OwJ\nL7+cyjc4CVlTWnKPaEPgJqBhXMs7wBERMaXMsbUq3yMyq6znn0+DEvbfHy64wOW8a1VVDFYoCWYl\ngJJZDWqKE5FZ5dx3XyrjfcEFae44q11V8UCrpI6kOj9dgQ5pNDdExP+UMzAzqz0RcNFF8Kc/wR13\nwE47FR2R1YKWDFa4HfgY+D8+P3rOzOwzn3wCP/tZKmY3frwrqVrLtSQRrRMRW5Q9EjOrWTNmwEEH\npbINY8e6kqp9OS0ZNTde0mZlj8TMatLkyWnm7O99z+W87atpyai5p4GNgJdIFVoFRETUVN1ED1Yw\na3233QbHHw+XXQaHHFJ0NFYOVTFYgTRQwczsMxGpnPc118D998N22xUdkdWyZhORpBXz4jsVisXM\nasC//w1HHw2vvOJy3tY6FnWP6FngmfzfZxu9fmZJdyzpVEnPSHpK0lBJHSV1lTRe0ouSbpLUIa/b\nUdIwSVMljcsTsTZ8zlm5/XlJey1pXGbWvOnT06zZyywD9fVOQtY6mk1EEbFWRKyd/7tWo9dLNDBT\n0hrAz4FtI2Ir0pXZYcD5wIURsTEwCzgmb3IM8H5EbAhcDFyQP2cz4BBgU6AncLkaHnQys1Y1YUIa\nlHDwwamqqst5W2spstLq0sA38lXPcsAbwB4snNl7MAvvTx2QXwPcCuyZl/cHhkXEvIh4BZgKdCt/\n6Gbty9ChsN9+cOWVcMYZ4D/3rDW1ZLBCq4uINyRdCLwG/JtU8fVxYFZELMirTQfWzMtrAtPytvMl\nzZa0cm4fV/LRr5dsY2ZLaMEC+PWv07Dshx6CLfxEoZVBIYkoz1t3ALAOMBv4K6lrrbGG8dZN/f0V\ni2g3syX0r3/BT36SynpPmADf/GbREVlb1ZK55uoior5R208iYugS7Pd7wMsR8X7+vNuBnYCVJC2V\nr4q6kLrrIF0drQW8IWlpoFNEzJTU0N6gdJsv6N+//2fLdXV11NXVLcEhmLVdL7+cZs3eeWe49Vbo\n2LHoiKxS6uvrqa+vr+g+W/JA61hSt9npwPLA1Xm7r/x8kaRuwEBge9JDsoOAx4DdgNsi4mZJVwBP\nRsSVkk4EtoiIEyX1An4YEb3yYIWhwA6kLrnRwIZNPbnqB1rNWubhh+HQQ+E3v0mVVH0/qH2rijIQ\nkpYiJaGjSAMMfhsRNyzxjqVzgF7AXOAJ4FjSFc0woHNuOyIi5uaKsDcA3wHeA3rlwQlIOos0qm4u\n0C8iRjWzPycis8W4+uqUgIYOTVP2mFVLIloJuAL4FvBt0tXLhbX2W92JyKx58+alct6jR8Ndd8GG\nGxYdkVWLSiSilgzfngiMiYjvkYZGrwf8rZxBmVnlvP8+7LMPTJ2ayjc4CVmlteSKaN2I+Gejtj0j\n4qGyRtbKfEVk9kUvvJCeD9pvv1RNtUMh42itmlXFpKcR8U9JnYD1gYZnqT8uZ1BmVn733w+9e8N5\n56W548yK0pLh20cD/0kalfY0aaTbeKCurJGZWVlEwMUXpyug226DXXYpOiJr71pyIX4q8B/AuIjY\nVdLmwG/LG5aZlcMnn6Qh2ZMmpftB66xTdERmLRus8HFEfARpFuyIeBbYuLxhmVlre/vtNCT7/fdT\nOW8nIasWzSaihhIMwJt5CPddwEhJw0kzHZhZjXjySejWDerqYPhwWH75oiMyW6jZUXOSHm9cDlzS\nd4FOwD0R8UkF4ms1HjVn7dXtt8Nxx8GAAXDYYUVHY7Wm6FFzX9hxRDxYxljMrBVFwH//N1x1Fdx7\nL2y/fdERmTVtUYnoW5J+2dybEfG/ZYjHzFrBRx+lIdkvv5xmzl5jjaIjMmveohLR0qRJTj3loVkN\nef11OOAA2GSTVM57ueWKjshs0b7UPaJa5ntE1h5MnAgHHQQnn+xKqtY6qu4ekZlVr5tugn794Npr\nUy0hs1qxqET03YpFYWZf2YIF8P/+X0pEDz4IW25ZdERmX06ziaiheqqZVa9//QuOPDI9pDpxInzr\nW0VHZPbltWRmBTOrQq+8kkp5f+tb8MADTkJWuwpLRJI6SfqrpOclPStpB0mdJY2S9KKkkXnW74b1\nB0iaKmmypG1K2vtImpK36V3M0ZhV1iOPwI47wrHHpqqqHTsWHZHZV1fkFdElwL0RsSmwNfACcCbw\nQERsDDwEnAUgqSewfkRsCBwPXJnbOwNnk2YE3wE4pzR5mbVF114LBx8MQ4bAL37hkXFW+wopgyVp\nBWDXiDgKICLmAbMlHQDsnlcbDIwhJacDgCF53Qn5amo1YA9gVETMzp87CtgHuLmCh2NWEfPmwa9+\nBffdB3/7G2y0UdERmbWOouoxrge8K2kQ6WpoEnAKsFpEzACIiLckrZrXXxOYVrL99NzWuP313GbW\npsycCYcemq5+xo+Hzp2Ljsis9RSViDoA2wInRcQkSReRrnyae+K0ceeD8rpNdUo0+9Rq//79P1uu\nq6ujrq6u5RGbFeTFF9NzQfvuC3/8o8t5W3nV19dTX19f0X02O7NCWXeautXGRcR6+fUupES0PlAX\nETMkrQ6MiYhNJV2Zl2/O679A6sLbI6//s9z+ufUa7dMzK1jNGTUKjjgC/ud/0sAEs0qrxMwKhQxW\nyN1v0yQ19HJ/F3gWGAEclduOAu7MyyOA3gCSugOz8meMBHrke0adgR65zaymRcAll0CfPql+kJOQ\ntWVFXuT/AhgqaRngZaAvaaLVWyQdDbwGHAwQEfdK2lfSS8CcvC4RMVPS70j3mAI4NyJmVf5QzFrP\np5/CSSelWbPHjYOuXYuOyKy8CumaK4K75qwWvPMO/PjHsNJK8Je/wAorFB2RtXdttmvOzL7o6adT\nOe9ddklVVZ2ErL3w+BuzKnDnnfDTn8LFF8PhhxcdjVllORGZFSgCzjsPLrsM7r47XRGZtTdORGYF\n+eijNBpuypQ0MGFNP4pt7ZTvEZkV4I03oK4u1RJ65BEnIWvfnIjMKuyxx2CHHdJsCTfeCMstV3RE\nZsVy15xZBd10U5ox++qr4cADi47GrDo4EZlVwIIF8JvfwNChqZz3VlsVHZFZ9XAiMiuzDz9M88W9\n914q573qqovfxqw98T0iszJqKOe9yirpSshJyOyLnIjMyuTRR1M57759U1VVl/M2a5q75szKYOBA\nOOssuOEG2HvvoqMxq25ORGataN48OO00uOeeVM57442Ljsis+jkRmbWSWbNSOe8FC9JMCS7nbdYy\nvkdk1gqmTIHu3WGTTeC++5yEzL4MJyKzJTR6NOy6K/zyl6mqagf3M5h9KYUmIklLSXpc0oj8uquk\n8ZJelHSTpA65vaOkYZKmShonae2Szzgrtz8vaa+ijsXanwgYMACOPBJuuQWOO67oiMxqU9FXRP2A\n50penw9cGBEbA7OAY3L7McD7EbEhcDFwAYCkzYBDgE2BnsDlkspaSdAMUjnv44+Ha65J5bx3373o\niMxqV2GJSFIXYF/g2pLmPYHheXkw8MO8fEB+DXBrXg9gf2BYRMyLiFeAqYArulhZvfMO9OgBb70F\nf/87rLtu0RGZ1bYir4guAk4DAkDSKsDMiFiQ358ONEyOvyYwDSAi5gOzJa1c2p69XrKNWatrKOe9\n444u523WWgq5rSrp+8CMiJgsqa6hOf+UipL3GotFtDepf//+ny3X1dVRV1fX3KpmXzBiBBxzDFx0\nUZo7zqwtqq+vp76+vqL7VESzv7fLt1Ppf4AjgHnAcsAKwB3AXsDqEbFAUnfgnIjoKen+vDxB0tLA\nmxGxqqQzgYiI8/PnfrZeE/uMIo7Val8EnH8+XHopDB+eagmZtReSiIiy3nsvpGsuIv4rItaOiPWA\nXsBDEXEEMAY4OK/WB7gzL4/Ir8nvP1TS3iuPqlsX2ACYWIljsPbh44/TqLhbb4Xx452EzMqh6FFz\njZ0J/FLSFGBlYGBuHwh8U9JU4JS8HhHxHHALaeTdvcCJvuyx1vLmm2k03Lx5qZx3ly5FR2TWNhXS\nNVcEd83ZlzFpUqqgevzx8Otfgx8KsPaqEl1zfgbcrJGbb4aTT3Y5b7NKcSIyyxYsgP79YcgQeOAB\n2HrroiMyax+ciMxI5bx794a333Y5b7NKq7bBCmYV9+qrqZz3Siu5nLdZEZyIrF0bOzbNknDUUamq\n6te+VnREZu2Pu+as3Ro0CM44AwYPhp49i47GrP1yIrJ2Z/58OP30NGXPww/DppsWHZFZ++ZEZO3K\n7Nlw2GGpjMOECbDyykVHZGa+R2TtxtSpqZz3euulct5OQmbVwYnI2oUHH4RddoFTTkmTly6zTNER\nmVkDd81Zm3f55fDb36YZE1z5w6z6OBFZmzV3LvziF2nC0rFjYf31i47IzJriRGRt0nvvwY9/DMsv\nD+PGwYorFh2RmTXH94iszbn7bthmm1TS+447nITMqp2viKzNeOcd6NcvDcsePBj23LPoiMysJXxF\nZDXv2WfhtNNgiy1gjTXg6aedhMxqSSGJSFIXSQ9Jek7S05J+kds7Sxol6UVJIyV1KtlmgKSpkiZL\n2qakvY+kKXmb3kUcj1XezJlwxRWp+22vvaBDB/jb3+BPf4Kvf73o6MzsyyikQquk1YHVI2KypOWB\n/wMOAPoC70XEBZLOADpHxJmSegInR8T3Je0AXBIR3SV1BiYB2wLKn7NtRMxuYp+u0Frj5s+H0aPh\n+uvh/vtwRpnpAAAMK0lEQVRh772hb1/o0QOWXrro6MzapjZboTUi3gLeyssfSnoe6EJKRrvn1QYD\nY4Azc/uQvP4ESZ0krQbsAYxqSDySRgH7ADdX8HCszKZMSclnyBBYffWUfC6/3DMjmLUVhQ9WkNQV\n2AYYD6wWETMgJStJDZVh1gSmlWw2Pbc1bn89t1mN++ADuOWWlICmToUjjkjT8my5ZdGRmVlrKzQR\n5W65W4F++cqoub6zxpeFAqKJdnJ7k/r37//Zcl1dHXV+zL6qLFgA9fUp+YwYAXvskWbJ7tnTU/KY\nVUp9fT319fUV3Wch94gAJHUA7gbui4hLctvzQF1EzMj3kcZExKaSrszLN+f1XiB14e2R1/9Zbv/c\neo3253tEVeqf/0zDrQcPTs/89O0Lhx/uSqlm1aAS94iKHL59HfBcQxLKRgBH5eWjgDtL2nsDSOoO\nzMpdeCOBHvmeUWegR26zKjdnTrrns8ceaeTbe+/B8OEweXKamNRJyKz9KGrU3M7AI8DTpK60AP4L\nmAjcAqwFvAYcHBGz8jaXkgYizAH6RsTjuf0o4Nf5M34fEUOa2aeviAoWkeZ8GzQIbrsNdtopXf3s\nt59LdJtVq0pcERXWNVdpTkTFmTYtXf1cf3163qdvXzjySPj2t4uOzMwWp80O37a276OP0jxv118P\njz0GhxwCN9wAO+wAKuspbWa1xonIWk0ETJyYks8tt8B226WrnzvugOWWKzo6M6tWTkS2xN58E/7y\nl3Tv59NP4aij4IknYO21i47MzGqBE5F9JZ9+CnfdlZLP2LFw4IFw1VWpHLe73szsy3Aisi/l9dfh\n0kth4EDYfPPU9TZsWCpAZ2b2VbgMhLXIc89B795pip05c1LV0zFjUpuTkJktCSciW6QIuPpq2H13\n2Gwz+Mc/YMAAWH/9oiMzs7bCXXPWrA8/hOOPh6eeSrV+Ntmk6IjMrC3yFZE16ZlnYPvtYdllU+lt\nJyEzKxcnIvuCQYPSHHBnnpkGJbjiqZmVk7vm7DP//jecdBKMH58GImyxRdERmVl74CsiA+D559Ms\n2HPnpil5nITMrFKciIyhQ2G33aBfvzQfnIdjm1kluWuuHfvoo1T7Z8wYeOAB2HrroiMys/bIV0Tt\n1NSpsOOOMHs2TJrkJGRmxWkTiUjSPpJekDRF0hlFx1PtbrklFaU77ji46aZUntvMrCg1n4gkLQVc\nCuwNbA4cJslPvTThk0/g5JPhlFPquf9+OPFET1BaX19fdAhVw9/FQv4uKqvmExHQDZgaEa9GxFxg\nGHBAwTFVnZdfhp13hjfegN6969luu6Ijqg7+hbOQv4uF/F1UVltIRGsC00peT89t7d78+TB5Mlx4\nIXTvnspzDx+eZkswM6sWbWHUXFOdS9HUivvtV+ZIqsjHH6dBCKutloZm33NPmrLHzKzaKKLJ39k1\nQ1J3oH9E7JNfnwlERJzfaL3aPlAzs4JERFnvJreFRLQ08CLwXeBNYCJwWEQ8X2hgZmbWIjXfNRcR\n8yWdDIwi3fMa6CRkZlY7av6KyMzMaltbGDW3SG31YVdJXSQ9JOk5SU9L+kVu7yxplKQXJY2U1Klk\nmwGSpkqaLGmbkvY++ft5UVLvkvZtJT2V37u4skf45UhaStLjkkbk110ljc/HdJOkDrm9o6Rh+XsY\nJ2ntks84K7c/L2mvkvaaOockdZL013wcz0raoR2fF6dKeibHOzT/+7eLc0PSQEkzJD1V0lb282BR\n+2hWRLTZH1KifQlYB1gGmAxsUnRcrXRsqwPb5OXlSffJNgHOB07P7WcA5+XlnsA9eXkHYHxe7gz8\nA+gErNSwnN+bAHTLy/cCexd93Iv4Pk4F/gKMyK9vBg7Oy1cAx+flE4DL8/KhwLC8vBnwBKm7ums+\nb1SL5xBwPdA3L3fI/7bt7rwA1gBeBjqWnBN92su5AewCbAM8VdJW9vOguX0sMtaiv6wy/0N0B+4r\neX0mcEbRcZXpWO8Avge8AKyW21YHns/LVwKHlqz/PLAa0Au4oqT9ivw/4erAcyXtn1uvmn6ALsBo\noI6FiegdYKnG5wFwP7BDXl4aeLupcwO4L/8PWVPnELAC8I8m2tvjebEG8Gr+ZdoBGAH0AN5uL+cG\nKUmWJqKynwdN7OOFxcXZ1rvm2sXDrpK6kv7yGU86AWYARMRbwKp5tea+i8btr5e0T29i/Wp0EXAa\n+fkxSasAMyNiQX6/NPbPjjci5gOzJa3Mor+HWjqH1gPelTQod1VeLenrtMPzIiLeAC4EXiPFPxt4\nHJjVTs8NgFUrcB40Pte+tbig2noiavHDrrVK0vLArUC/iPiQ5o+v8XehvG5z31FNfHeSvg/MiIjJ\nLIxZfDH+KHmvsZr/Hkp0ALYFLouIbYE5pL/U29V5ASBpJdJ0X+uQro6+QeqCaqy9nBuLUuh50NYT\n0XRg7ZLXXYA3Coql1eWbrLcCN0TEnbl5hqTV8vurk7ohIH0Xa5Vs3vBdNPcdNbd+tdkZ2F/Sy8BN\nwJ7AxUAnpQlx4fOxf3ZcSs+gdYqImXz576daTQemRcSk/Ho4KTG1t/MCUlf1yxHxfr7CuR3YCVip\nnZ4bUJnz4K1m9tGstp6IHgM2kLSOpI6kfswRBcfUmq4j9dNeUtI2AjgqLx8F3FnS3hs+m41iVr58\nHgn0yCOtOpP60EfmS+oPJHWTpLztnVSZiPiviFg7ItYj/fs+FBFHAGOAg/Nqffj899AnLx8MPFTS\n3iuPnFoX2ID0cHRNnUP533SapI1y03eBZ2ln50X2GtBd0rI51obvoj2dG417BypxHpTuo/T7bV7R\nN9MqcLNuH9KIsqnAmUXH04rHtTMwnzRS5wlS3/c+wMrAA/mYRwMrlWxzKWmUz5PAtiXtR+XvZwrQ\nu6R9O+Dp/N4lRR9zC76T3Vk4WGFd0qieKaRRUsvk9q8Bt+RjGg90Ldn+rPz9PA/sVavnELA16Zfk\nZOA20oindnleAOfkf8+ngMGk0W3t4twAbiRdpXxCSsp9SQM3ynoeLOpca+7HD7SamVmh2nrXnJmZ\nVTknIjMzK5QTkZmZFcqJyMzMCuVEZGZmhXIiMjOzQjkRmZWQtGouF/CSpMckjZV0QAX220nSuyWv\nd5S0QNIa+fWKkt4rdxxmRXAiMvu8O4D6iNggIrYnPS3fpfFKeQqYVhMRs4E3JW2Sm3YkPaS8U37d\nnfSQpVmb40RklknaE/gkIq5paIuIaRFxWX6/j6Q7JT1IenIcSX9UKkz4pKRDctvqkh7Os18/JWln\npcJ9g/LrJyX1ayKEv7Mw8exEmlW89PXf8+cfK2mipCeUCuAtm9vXUyro9qSk30n6V8mx/SpvM1nS\nOa34tZktMScis4U2J12FLMp3gIMiYg9JBwFbRcSWpDm4/pgnezwcuD/S7Ndbk6ba2QZYMyK2ioit\ngUFNfHZpIloX+CuwfX69EzA2Lw+PiG4R8R1S7ZdjcvslwEX586ezsCxGD2DDiOiW4/8PSbu07Csx\nKz8nIrNmSLo0X0FMKGkenbvRIFXAvAkgIt4G6kmJ4zHgaElnkxLVHFKl0HUlXSJpb+BffNFYYOdc\nX+qViPg0x/EN0rxeE/N6W0p6RKkE9OGkBAqpO+/WvHxjyefuRZq48nFSot0Y2PDLfh9m5eJEZLbQ\ns6Rf+ABExMmkGZtLC3vNKVluqoYLEfE3YFdSEbHrJR0REbNIV0f1wPHAtY13HhEvkSal3A8Yl5v/\njzRZ5csR8e/cdj1wYkRsBfwWWLbhI5qJTcAfImLbiPhORGwUEU1dkZkVwonILIuIh4CvSTq+pPkb\ni9jkEeDQfP/nW6TkM1HS2sA7ETGQlHC2zZU+l46I24HfkLrImjIO6MfCRDQeOIV8fyhbnlTzZRng\nJyXt44Ef5+VeJe0jSVdo3wCQtEaO16wqdCg6ALMq80PgYkmnA++QroBOb2rFiLg91255ElgAnBYR\nb0vqDZwmaS6pC643aeTdoFyQLUhVU5syllRFtKGw3TjS/aKxJev8htRN9zapnMEKuf1U4C+S/ouU\nfGbnOEfn0XjjUukY/gUckY/PrHAuA2HWRkhaLiI+ysuHAr0i4sCCwzJbLF8RmbUd20m6lHRPaCZw\ndMHxmLWIr4jMzKxQHqxgZmaFciIyM7NCORGZmVmhnIjMzKxQTkRmZlYoJyIzMyvU/wf4YXOHQprV\n0AAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<matplotlib.figure.Figure at 0x7fad83d06950>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "plt.plot(gross_wage,income_tax)\n",
     "plt.ylabel(u\"Tax Income\")\n",
@@ -206,52 +130,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/edarin/.virtualenvs/openfisca/lib/python2.7/site-packages/ipykernel/__main__.py:1: RuntimeWarning: invalid value encountered in divide\n",
-      "  if __name__ == '__main__':\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "average_rate = income_tax / gross_wage  "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.text.Text at 0x7fad83e9a850>"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZkAAAEPCAYAAACQmrmQAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3Xm8lHXd//HXGwQ1za1yQzHNrXBfkFxPmnosk3LFXFPv\nFvVO885E885Dm0uLWqRlmhl6S+6CBSLqaCIgbqgoQpksgvvyI5VF+Pz++F7AOB5gjnLNNWfm/Xw8\nzoPruuY7c31mGM6H766IwMzMLA9dig7AzMwal5OMmZnlxknGzMxy4yRjZma5cZIxM7PcOMmYmVlu\nck8yklolTZQ0SdJZ7Ty+h6RHJM2TdHDFYxdKekrSBEmX5B2rmZktX7kmGUldgIHA/kAv4EhJW1YU\nmwIcB1xX8dzPA7tGxFbAVkBvSXvmGa+ZmS1fK+T8+r2ByRExBUDSYKAvMHFhgYiYmj1WOSs0gJUk\nrURKhisAL+Ucr5mZLUd5N5f1AKaVnU/Pri1TRIwBSsBM4AXgzoh4dnkHaGZm+ck7yaida1WtYyPp\nM8CWwPqkxLSPpN2XY2xmZpazvJvLpgM9y843AGZU+dyvAWMi4l0AScOAPsAD5YXaaWYzM7MqRER7\nFYHlKu+azDhgU0kbSeoO9AOGLKV8+RueCuwlqaukbsBewDPtPSki/BPBeeedV3gM9fLjz8KfhT+L\npf/USq5JJiLmA6cCI4AJwOCIeEbSAEkHAkjaSdI04FDg95KezJ5+E/Ac8CTwGPBYRPwtz3jNzGz5\nyru5jIgYDmxRce28suOHgQ3bed4C4Nt5x2dmZvnxjP8G0tLSUnQIdcOfxWL+LBbzZ1F7qmXbXB4k\nRWd/D2ZmtSaJaICOfzMza2JOMmZmlhsnGTMzy42TjJmZ5cZJxszMcuMkY2ZmuXGSMTOz3DjJmJlZ\nbpxkzMyaTC3nrzvJmJk1iQj4299gxx1rd08nGTOzJnDPPbDrrnDWWXDuubW7b+6rMJuZWXHGjoUf\n/hCmTIEBA+CII6Br19rd3zUZM7MGNHYsfPWrcOihKbE8/TR8/eu1TTDgmoyZWcOYPx/uuAN++UuY\nNg2+9z24/npYeeXiYso9yUhqBS4h1ZquiogLKx7fI3t8G+CIiLil7LENgStJm5otAL4UEVPzjtnM\nrDN4++1UY3ngARg1CsaMgS23hDPOgEMOgRXqoBqR634ykroAk4B9gBnAOKBfREwsK9MTWA34PjCk\nIsncC/wkIu6R9DFgQUTMrriH95Mxs6bw2mspodx/P/zjHzBhAmy7Ley+e/rZdVf45Cere61a7SeT\nd57rDUyOiCkAkgYDfYFFSWZhzUTS+zKFpM8CXSPinqzcOznHamZWV158Ee67LyWV+++HqVPh85+H\nPfZITWI771xsU1g18k4yPYBpZefTSYmnGpsDb0m6Gfg0MBLo72qLmTWqF1+EUmnxz8svp4Sy117w\njW/AdtvVRxNYR+QdbntVsWqTxArA7sB2pER1A3A8cHVlwba2tkXHLS0t3sfbzDqF119PyeSee9LP\nzJmw557Q0gLf/jZsvfXyGw1WKpUolUrL58U6IO8+mT5AW0S0Zuf9gajs/M8euxoYurBPRtIuwPkR\nsXd2fjSwS0T8d8XzXLkxs07h3XdTn8rIkXD33TBpEuy2G+y9d/rZbrvaDTFulD6ZccCmkjYCZgL9\ngCOXUr78DY8D1pT0iYh4Ddg7u2Zm1iksWACPPw4jRqTEMnZs6qj/4hfh4othl12ge/eio8xXrjUZ\nWDSE+VIWD2G+QNIAYFxE3CFpJ+BWYA1gNvBiRGydPXcf4NfZSz0CfDMi3qt4fddkzKxuvPRSSirD\nh8Ndd8Faa8F++8G++6a+ldVWKzrCpFY1mdyTTN6cZMysSO+9l+an/P3vKbH8+9+p6au1NSWXjTYq\nOsL2OclUyUnGzGrtlVdg2LCUWEaMSInkgAPST58+0K1b0REum5NMlZxkzCxvEfDkkzBkSFoq/+mn\nYZ994EtfSomlR4+iI+w4J5kqOcmYWR7mzk0TIYcMST9du8JXvgIHHpiGGa+4YtERfjSNMrrMzKzT\nmDUrNYHdfntqDttiCzjooFR76dULlPuv5MbjmoyZNbVXX001lVtuSUu37L57WiL/K1+B9dYrOrr8\nuLmsSk4yZtZRL76YksrNN8PDD6dRYAcfnPpYVl+96Ohqw0mmSk4yZlaNhYnlhhtg/Hj48pfTcvj7\n7w8f+1jR0dWek0yVnGTMbElefTUllsGD4bHHUmI5/PBUc1lppaKjK5aTTJWcZMys3H/+kzrur7su\nbeTV2gr9+qWhxs2eWMo5yVTJScbM5s1LS7gMGpRGhe2+e9rP/qCDYNVVi46uPjnJVMlJxqw5RcCj\nj8Jf/pKawz7zGTj66NQcVu3ukM3M82TMzNoxY0aqsfzlLzB7NhxzDDz4YEoyVn+cZMys7s2ZA0OH\nwtVXw+jRaVTYH/6Q9mLxBMn65iRjZnVrwgS46iq49lrYais44QS48cbmHHLcWTnJmFldeecd+Otf\n4YorYOrUtLf96NFuDuus3PFvZnXhqafg97+H66+HXXeFb34zDTtewf8VzkWtOv675H0DSa2SJkqa\nJOmsdh7fQ9IjkuZJOridxz8uabqk3+Qdq5nV1pw5KanssUeaef+JT6RJk0OHprXDnGA6v1z/CiV1\nAQYC+wAzgHGSbo+IiWXFpgDHAd9fwsv8BCjlGaeZ1dYLL8Dll8OVV6a+ltNPT3NaOsNmX9Yxeddk\negOTI2JKRMwDBgN9ywtExNSIeAr4QJuXpB2BtYEROcdpZjmLgAceSPNYtt4a3noLSiUYOTKNFnOC\naUx5V0Z7ANPKzqeTEs8ySRLwS+Bo4IvLPzQzq4U5c9KilJdemhLLf/93qsGstlrRkVkt5J1k2utU\nqraX/mTgbxHxQso37b4WAG1tbYuOW1paaGlpqT5CM8vF66+njvyBA9OGX21taSn9Lrn3BFt7SqUS\npVKp5vfNdXSZpD5AW0S0Zuf9gYiIC9spezUwNCJuyc6vBXYHFgAfB7oBl0XEORXP8+gyszry73/D\nxRenuS0HHQRnnAHbbFN0VFapUZaVGQdsKmkjYCbQDzhyKeUXveGIOHrRRek4YMfKBGNm9eOxx+Ci\ni9JClSedlIYkr79+0VFZ0XKtuEbEfOBUUsf9BGBwRDwjaYCkAwEk7SRpGnAo8HtJT+YZk5ktPxFp\ny+LW1jTkeKed4Lnn4IILnGAs8WRMM+uwiLSk/s9/Di+9BP37p4Uqu3cvOjKrVqM0l5lZA1mwAIYM\ngZ/+FObOhR/+EA49FLp2LToyq1dOMma2TAsWwG23wYABKaH86EepU98jxWxZnGTMbIki0hIv552X\nEsrPfgZf/rKX17fqOcmY2QdEpFFi556bJlP++Mep5uLkYh3lJGNm7zNqVOprmTkTfvKT1OfiZjH7\nsJxkzAyAp5+Gs8+Gxx9Ps/OPOcarINtH5/+fmDW5GTPS5MmWFthzT3j22bRRmBOMLQ9OMmZN6j//\nSR36W28Nn/wkTJoE//M/sNJKRUdmjcRJxqzJzJ+fVkHefHP417/g0UfTDP011ig6MmtErhCbNZH7\n74fTToNVVoHbb4eddy46Imt0TjJmTWDqVDjzTBg9Gn7xi7RxmIcjWy24ucysgc2Zk9YX23572HJL\nmDgRjjjCCcZqxzUZswY1fHjahbJXLxg3DjbZpOiIrBk5yZg1mBdegNNPTx36v/1t2o3SrChuLjNr\nEPPnw6WXwrbbpqaxp55ygrHiuSZj1gCeeCJNqFx5ZXjggZRkzOrBMmsykj4l6Q+S7sjOPyfp+Gpv\nIKlV0kRJkySd1c7je0h6RNI8SQeXXd9W0oOSnpT0uKTDq72nWbOYPTutM/bFL8I3vwn33usEY/Wl\nmuayPwP3ARtm55OB/6nmxSV1AQYC+wO9gCMlVf4TmAIcB1xXcf1t4JiI2Bo4ALhE0mrV3NesGYwe\nDdttl5aBGT8+1WS8kKXVm2q+kmtHxP8BCwAiYh4wv8rX7w1Mjogp2fMGA33LC0TE1Ih4CoiK6/+M\niH9lxzOBl4FPVXlfs4b1zjtp+ZeDD047VN50E6y3XtFRmbWvmiTztqS1yJKApJ2BWVW+fg9gWtn5\n9Oxah0jqDXRbmHTMmtWYMWnOy8yZ8OSTaRl+s3pWTcf/mcBQYBNJ95GSxGFVvn57U76inWtLfgFp\nPeAvwDFLKtPW1rbouKWlhZaWlo7cwqzuzZ2bNg678kr43e/gkEOKjsg6m1KpRKlUqvl9FbH03/mS\nViDVeD5LShpPAwsi4r1lvrjUB2iLiNbsvD8QEXFhO2WvBoZGxC1l1z4OlICflV+veF4s6z2YdWYT\nJsDRR8OGG8IVV8C66xYdkTUCSURE7ms/VNNc9lBEzI2I8RHxeETMBR6q8vXHAZtK2khSd6AfMGQp\n5Re9YUndgNuAa5aUYMwaWQQMHJj2eTnllLSgpROMdTZLbC6TtDawHrCypK1ZnABWAz5WzYtHxHxJ\npwIjSAntqoh4RtIAYFxE3CFpJ+BWYA3gQElt2Yiyw4HdgTUlfYPUzHZ8RDzxod6pWSfy0ktp47BX\nX4UHH4TNNis6IrMPZ4nNZdkv9hOA7YDHyx6aBVwdETfmH96yubnMGs1dd8Fxx8EJJ6RNxbp1Kzoi\na0S1ai6rpk/m8Ii4Ie9APiwnGWsU770HP/oRXHMNDBoEe+9ddETWyGqVZJY5uiwibpC0cDLlSmXX\nf55nYGbNZPp06NcvbSb22GOw9tpFR2S2fFSzrMxlpBn5ZwArA0cDm+Ycl1nTuOuutEPlAQfAsGFO\nMNZYqmkueyIitpE0PiK2zYYV/y0i9qxNiEvn5jLrrBYsSDP2f/97uO46+MIXio7ImkndNJcB72Z/\nzpa0LvAasH5+IZk1vjffhKOOglmz4OGHYX3/i7IGVc08mWGS1gB+SRpl9jxQFyPLzDqjp55KzWOb\nbgp33+0EY41tmc1l7yssrQysHBGv5xdSx7i5zDqTW26Bb30LfvUrOPbYoqOxZlZPM/4XiYh3gW0l\nDcspHrOGFJHWHjv9dBg+3AnGmsfSZvzvBVxO6n+5DbgI+BNphNnPahKdWQN45x04/niYNg0eeshL\nw1hzWVpN5hLgu6RVl+8AxgLXR8S29Tw506yevPAC7LFH2hb53nudYKz5LLW5LCJGRsTbEXETMCMi\nLq1RXGad3vjx8PnPw2GHwZ//DCuttMynmDWcpQ1hXl3SQeVly88jYmmrKZs1tWHD0vpjAwfC4YcX\nHY1ZcZa2QOagpTwvIqIuui49uszqzRVXpIUtb74Zdt216GjM2lc3C2TWOycZqxcR0NaWZu8PG+bl\n+a2+1dOMfzNbhvfeg+98Jy1uOWoUrLNO0RGZ1YcOzZP5MCS1SpooaZKks9p5fA9Jj0iaJ+ngiseO\ny573rKS6aJ4zqzR7NhxySBqiXCo5wZiVy7W5TFIXYBKwDzCDtB1zv4iYWFamJ2m3ze8DQxZutSxp\nTeBhYAfSrpyPADtExFsV93BzmRVm1izo2zcllmuuge7di47IrDp1M+Nf0nmSupadryrpj1W+fm9g\nckRMiYh5wGCgb3mBiJgaEU+Rtlcutz8wIiLeiog3SVs4t1Z5X7PcvfYa7LMPbL45XHutE4xZe6pp\nLlsVGCOpl6S9SbWLCVW+fg9gWtn59Ozah3nuCx14rlmuZs6EvfZKy/Nffjl07brs55g1o2p2xjxT\n0r6kpq43gZaImFTl67dXFau2beujPNcsN9Onp62Rjz0Wzj236GjM6tsyk4ykXYGLgfOBrYBfSzop\nIl6s4vWnAz3Lzjcg9c1UYzrQUvHce9sr2NbWtui4paWFlpaW9oqZfWRTpqQE853vwPe/X3Q0ZtUr\nlUqUSqWa37eanTEfBr4REU9m50cAP46ILZb54qkv51lSx/9M4CHgyIh4pp2yVwN3RMTN2Xl5x3+X\n7HjHrH+m/Hnu+LeaeO65lGDOOAO++92iozH7aOpmMqakFSLivYprn4qIV6q6gdQKXEpKFFdFxAWS\nBgDjIuIOSTsBtwJrALOBFyNi6+y5xwM/JDWT/TQi/tLO6zvJWO7+/W9oaYH+/VMtxqyzq5skkwWz\nP9ALWLTEX0T8PMe4quYkY3mbOjV18n//+3DKKUVHY7Z81M2Mf0mXkWoZewJXA4cAY3KOy6wuLOzk\nP+00JxizD6Oa5rInImIbSeMjYltJHwf+FhF71ibEpXNNxvLy0kuw555w0klw5plFR2O2fNXNZEzg\n3ezP2ZLWJfWbrJ9fSGbFe+MN2G8/+PrXnWDMPopqFsgcJmkN4JfA48B84JpcozIr0H/+A1/+cprN\n/6MfFR2NWee2tP1k+kTEmIprKwMrR8TrtQiuGm4us+Vpzhw48EDo2ROuvBKUe2OCWTEKH10m6dGI\n2CHvAD4qJxlbXhYsgH790r4wgwd7qRhrbHUzusysGUTA974HL78Mw4c7wZgtL0tLMptIGrKkByPi\noBziMSvEL34B994L998PK6207PJmVp2lJZlXgF/VKhCzolx7Lfzud/Dgg7DGGkVHY9ZYlpZkZkXE\nfTWLxKwApVJai6xUgh7eSMJsuVvaPJnnaxWEWRGefRaOOAKuvx4+97miozFrTLluv1wLHl1mH8ar\nr0KfPnD22XDiiUVHY1Z7hQ9h7iycZKyj5sxJEy332APOP7/oaMyK4SRTJScZ64iIVHN56y248Ubo\nUs3CSmYNqG7myUgScBSwSUT8WFJPYN2IeCjv4MyWt9/+Fh55BEaNcoIxq4VqVmG+HFgA7B0Rn812\nrBwRETvXIsBlcU3GqnX33XDUUTB6NGy8cdHRmBWrnlZh3iUiTiGtvkxEvAF0r/YGklolTZQ0SdJZ\n7TzeXdJgSZMljc5qSkhaQdKfJT0haYKk/tXe06zSc8+lFZUHD3aCMaulapLMPEldSVsgI+lTpJrN\nMknqAgwEFu6seaSkLSuKnQi8HhGbAZcAF2XXDwO6R8Q2wE7AtxYmILOOeOcdOPhgOPfctIWymdVO\nNUnmN8CtwNqSfgY8AFQ7Jqc3MDkipkTEPGAw0LeiTF8Wbx1wE7B3dhzAKlmC+xgwB/h/Vd7XDEgd\n/d/5Dmy1FZx6atHRmDWfZXb8R8R1kh4B9gEEfDUinqny9XsA08rOp5MST7tlImK+pLckrUVKOH2B\nmcDKwPci4s0q72sGwB/+AI8+CmPGeNl+syJUM7psUEQcA0xs59oyn97Otcpe+soyysr0Bt4D1gU+\nAfxD0siIeL6K+5oxdmzadGzUKFhllaKjMWtO1Sz136v8JGu+2rHK158OlPejbADMqCgzDdgQmJG9\n9moR8YakrwPDI2IB8IqkUaS+mecrb9LW1rbouKWlhRY3vDe911+Hww+HK66AzTYrOhqz4pVKJUql\nUs3vu7RNy84GziE1Vb3D4hrHXOCKiDh7mS+eksazpKa2mcBDwJHlzW2STga2ioiTJfUjNcf1k/QD\nYIuIOFHSKtlzj4iIpyru4SHM9j4R8NWvwiabwMUXFx2NWX2qmxn/ks6vJqEs5fmtwKWkQQZXRcQF\nkgYA4yLiDkkrAoOA7YHXgH4R8XyWWK4GFi5d+KeI+HU7r+8kY+/zm9/AX/6SmslWXLHoaMzqU90k\nmSyYNYHNgEXbOUXE/TnGVTUnGSv36KPQ2pomXH7mM0VHY1a/6mlZmZOA00j9KY8DfYDRLB5qbFYX\nZs1KS/f/9rdOMGb1opp5MqcBOwNTIuILpGYtDyW2unPaabDnninRmFl9qGZ02eyImC0JSStGxERJ\nW+QemVkH3HIL3H8/PP540ZGYWblqksx0SWsAtwF3SXoDmJJvWGbVmzEDTj4ZbrsNVl216GjMrFyH\n9pORtBewOmn+ytzcouoAd/w3twg44ADYZRcYMKDoaMw6j7oYXZYtcPl0RFQualk3nGSa2+9+l4Yr\nP/AAdOtWdDRmnUddjC6LiAWSnpXUMyKm5h2MWUf8619w3nlpPowTjFl9qqZPZk1ggqSHgLcXXoyI\ng3KLymwZFiyAE06Ac86BLTwMxaxuVZNk/jf3KMw6aOBAmD8/DVs2s/pV7Yz/jYDNImKkpI8BXSNi\nVu7RVcF9Ms3nn/+EPn3gwQdh882Ljsasc6qb7Zcl/Rdpb5c/ZJd6kIYzm9Xc3LnwjW/AD3/oBGPW\nGVQz4/8UYDeyXSkjYjKwdp5BmbVnwQI4/nhYay347neLjsbMqlFNn8yciJirbFtBSSvwwY3HzHIV\nAaefDtOnw513QteuRUdkZtWoJsncJ+kcYGVJ+wInA0PzDcvs/X7+c7jvvvSz8spFR2Nm1apmP5ku\nwInAfqSNy+4ErqyX3nZ3/Deu+fNh5Ej44x/TEv6jRsF66xUdlVljqIsZ/1kgXwP+HhFz8g7mw3CS\naTwzZsCVV8JVV8GnPgUnnQRHHgmrr150ZGaNo25GlwEHAZMkDZL05axPpmqSWiVNlDRJ0lntPN5d\n0mBJkyWNltSz7LFtJD0o6SlJ4yV178i9rfOIgFIJDj8cevWCmTPTgpcPPwzf/rYTjFlnVe08mW7A\nAcARwO7AXRFxUhXP6wJMAvYBZgDjSNsrTywr8x1g64g4WdIRwNciop+krsCjwFER8VS2O+ebldUW\n12Q6t9mz4frr4ZJLYN48OOUUOOYYWG21oiMza2x1sXbZQhExT9Iw0qiylYG+wDKTDNAbmBwRUwAk\nDc6eO7GsTF/gvOz4JuC32fF+wPiIeCqL4Y1qYrXO4bXX0uKWl10G228Pv/gF7LsvKPevvJnVUjWT\nMVsl/Rn4J3AocCVQbfdrD2Ba2fn07Fq7ZSJiPvCWpLWAzbP7D5f0sKQzq7yn1bGpU9NQ5M02gylT\n4J57YNgw2G8/JxizRlRNTeZ4YDDwrQ/R+d/er43Ktq3KMsrKrECaBLoTMBu4W9LDEXFv5Qu2tbUt\nOm5paaGlpaWDYVrenn8+DUO+6aa0sOWTT0KPyv9umFluSqUSpVKp5vft0KZlAJJ2A74eEadUUbYP\n0BYRrdl5fyAi4sKyMsOyMmOzfpiZEbF21j+zf0SckJU7F3g3In5VcQ/3ydSxKVPgJz+BW29NHfhn\nnAGf+ETRUZlZPY0uQ9J2ki6S9DzwU97fp7I044BNJW2UjQzrBwypKDMUOC47Pgy4Jzu+E9hG0krZ\niLa9gKervK8V7OWXU7PYDjvAuuvC5Mnws585wZg1myU2l0nanJQUjgReA/5Kqvl8odoXj4j5kk4F\nRpAS2lUR8YykAcC4iLgDuAoYJGlydp9+2XPflPRr4GFgAfC3iBj2Yd6k1c7bb8OvfgWXXgpHHQVP\nPw3rrFN0VGZWlCU2l0laAPwDODEi/pldey4iNqlhfMvk5rL6sGABXHttWh15t93g/PNh442LjsrM\nlqQehjAfQqpV3CtpOKnz3+N/7AMeeghOPTWNDvvrX2HXXYuOyMzqRTXLyqwCfJXUbLY3cA1wa0SM\nyD+8ZXNNpjivvw5nnw1DhsCFF8LRR0OXqnr5zKxoddPxHxFvR8R1EXEgsAHwONA/78CsfkXAoEHw\nuc9B9+7wzDNw7LFOMGb2QR0ewlxvXJOpralT01DkmTPTIpY77lh0RGb2YdRNTcYMUu3lD39ISWW3\n3VI/jBOMmS1Lh1ZUtub04otw4olp7st996VmMjOzargmY0t1++1pAcsddoAHH3SCMbOOcU3G2jVn\nDpx5JgwdmtYb2223oiMys87IScY+4Pnn0+ZhPXrAY4/BGmsUHZGZdVZuLrP3GTkSdtklbXd8yy1O\nMGb20XgIsy0ydiwceCDcfDPsuWfR0ZhZnjyE2Wrq2Wehb1+4+monGDNbfpxkjBkzoLU1LWp54IFF\nR2NmjcTNZU0uIvXB9O2bVlA2s+bg5jKriQcegFmz4Jxzio7EzBqRk0yT++Mf4b/+Ky3Tb2a2vOWe\nZCS1SpooaZKks9p5vLukwZImSxotqWfF4z0lzZJ0Rt6xNps33kjL9B97bNGRmFmjyjXJSOoCDAT2\nB3oBR0rasqLYicDrEbEZcAlwUcXjvwb+nmeczeq661KH/yc/WXQkZtao8q7J9AYmR8SUiJhH2l2z\nb0WZvqSN0ABuAvZZ+ICkvsC/gAk5x9l0IuCKK+Cb3yw6EjNrZHknmR7AtLLz6dm1dstExHzgTUlr\nSfoY8ANgAN72ebl76CF45x1oaSk6EjNrZHmvXdZecqgcb1xZRlmZAcDFEfGOUq/0EhNNW1vbouOW\nlhZa/Jtzmf74RzjpJO9madYsSqUSpVKp5vfNdZ6MpD5AW0S0Zuf9gYiIC8vKDMvKjJXUFZgZEWtL\nup+03TPAmsB84EcRcVnFPTxPpoNmzYKePdO2yeuuW3Q0ZlaEWs2TybsmMw7YVNJGwEygH3BkRZmh\nwHHAWOAw4B6AiFi0uImk84BZlQnGPpwbbkjNZE4wZpa3XBtLsj6WU4ERpM77wRHxjKQBkhYuYHIV\n8ElJk4HTgf55xmRw7bUetmxmteFlZZrM1Klpl8sXXoAVVyw6GjMripeVsVxcdx0ceqgTjJnVhpNM\nE4mAQYPg6KOLjsTMmoWTTBN57DGYPRt2263oSMysWTjJNJFrr021GC+GaWa14o7/JvHee7DhhnDf\nfbD55kVHY2ZFc8e/LVcjR6YJmE4wZlZLTjJN4rrr4Kijio7CzJqNm8uawOzZsN56XkbGzBZzc5kt\nN3fdBdts4wRjZrXnJNMEbrwRDjus6CjMrBm5uazBzZmTajATJsD66xcdjZnVCzeX2XIxciRstZUT\njJkVw0mmwbmpzMyK5OayBjZ3bmoqe/JJ6FG56bWZNTU3l9lHNnIkfPazTjBmVhwnmQZ2001uKjOz\nYuWeZCS1SpooaZKks9p5vLukwZImSxotqWd2/YuSHpY0XtI4SV/IO9ZGMm8e3H47HHJI0ZGYWTPL\nNclI6gIMBPYHegFHStqyotiJwOsRsRlwCXBRdv0V4MCI2BY4HhiUZ6yN5h//gE02SYtimpkVJe+a\nTG9gckRMiYh5wGCgb0WZvsA12fFNwD4AETE+Il7MjicAK0rqlnO8DWPoUPjKV4qOwsyaXd5Jpgcw\nrex8enY8iyujAAALaklEQVSt3TIRMR94U9Ja5QUkHQo8liUqW4YIJxkzqw8r5Pz67Q2PqxxvXFlG\n5WUk9QLOB/Zd0k3a2toWHbe0tNDS0tLBMBvLxIlppv922xUdiZnVi1KpRKlUqvl9c50nI6kP0BYR\nrdl5fyAi4sKyMsOyMmMldQVmRsTa2WMbAHcDx0XEmCXcw/NkKlx0ETz/PFx2WdGRmFm9apR5MuOA\nTSVtJKk70A8YUlFmKHBcdnwYcA+ApDWAO4D+S0ow1j43lZlZvch9xr+kVuBSUkK7KiIukDQAGBcR\nd0hakTRybHvgNaBfRDwv6YdAf2Ayi5vQ9ouIVyte3zWZMq+9lkaVvfQSrLRS0dGYWb2qVU3Gy8o0\nmEGD4JZb4NZbi47EzOpZozSXWY25qczM6olrMg1k7lxYZ500umyddYqOxszqmWsy1mH33w9bbOEE\nY2b1w0mmgQwfDl/6UtFRmJkt5iTTQEaMgP33LzoKM7PF3CfTIGbOhF694JVXoGvXoqMxs3rnPhnr\nkJEjYe+9nWDMrL44yTSIESNg3yWu7mZmVgw3lzWACFhvPRg9GjbeuOhozKwzcHOZVe3JJ+HjH3eC\nMbP64yTTANxUZmb1ykmmAYwYAfvtV3QUZmYf5D6ZTu7dd2HttWH6dFh99aKjMbPOwn0yVpUHHoBt\ntnGCMbP65CTTybmpzMzqWe5JRlKrpImSJkk6q53Hu0saLGmypNGSepY9dnZ2/RlJ/lVa4Y034K9/\n9XplZla/ck0ykroAA4H9gV7AkZK2rCh2IvB6RGwGXAJclD33c8DhwGeBA4DLJOXefthZLFgARx0F\nhxwCO++crpVKpUJjqif+LBbzZ7GYP4vay7sm0xuYHBFTImIeMBjoW1GmL3BNdnwTsHd2fBAwOCLe\ni4jnSdsw98453k5jwAB4+2246KLF1/wPaDF/Fov5s1jMn0XtrZDz6/cAppWdT+eDiWJRmYiYL+kt\nSWtl10eXlXshu9b07rgD/vQnePhh6Nat6GjMzJYs7yTTXvNW5XjjJZWp5rnvc8EFMGpUlZF1YmPG\npG2WvTmZmdW7XOfJSOoDtEVEa3beH4iIuLCszLCszFhJXYGZEbF2ZVlJw4HzImJsxT2ad5KMmdlH\nUIt5MnnXZMYBm0raCJgJ9AOOrCgzFDgOGAscBtyTXR8CXCfpYlIz2abAQ5U3qMWHZGZmH06uSSbr\nYzkVGEEaZHBVRDwjaQAwLiLuAK4CBkmaDLxGSkRExNOSbgCeBuYBJzf11H4zs06o0y8rY2Zm9atT\nz/hf1kTPzkjSBpLukfS0pCclfTe7vqakEZKelXSnpNXLnvObbNLq45K2K7t+XPbZPCvp2LLrO0h6\nInvsktq+w46T1EXSo5KGZOefljQme1/XS1ohu97hib2d6TskaXVJN2bvYYKkXZr1eyHpe5KeyuK9\nLvu7b5rvhaSrJL0k6Ymya7l/F5Z2jyWKiE75Q0qQ/wQ2AroBjwNbFh3Xcnhf6wLbZcerAs8CWwIX\nAj/Irp8FXJAdHwD8LTveBRiTHa8J/AtYHVhj4XH22Figd3b8d2D/ot/3Mj6T7wHXAkOy878Ch2XH\nlwPfyo6/A1yWHR9BmmcF8DngMVLz8Kez740623cI+DPwjex4hezvtum+F8D6wHNA97Lvw3HN9L0A\ndge2A54ou5b7d2FJ91hqrEV/WB/hQ+4DDCs77w+cVXRcObzP24AvAhOBdbJr6wLPZMe/B44oK/8M\nsA6pb+vysuuXZ//A1gWeLrv+vnL19gNsANwFtLA4ybwCdKn8HgDDgV2y467Ay+19N4Bh2T+2TvMd\nAj4O/Kud6033vSAlmSnZL8kVSIOE9gVebqbvBSkJlieZ3L8L7dxj4rLi7MzNZe1N9GyoyZqSPk36\n38oY0l/sSwAR8SKwdlZsSZ9D5fUXyq5Pb6d8vboYOJNsjpSkTwBvRMSC7PHy+N83sRcon9i7pM+i\ns3yHNgFelXR11nR4haSP0YTfi4iYAfwKmEqK/y3gUeDNJvxelFu7Bt+Fyu/bp5YVVGdOMh2erNmZ\nSFqVtMzOaRHxH5b83io/B7H0yayd5nOT9GXgpYh4nMVxiw++hyh7rFJDfBak/7HvAPwuInYA3ib9\nD7sZvxdrkJaj2ohUq1mF1CRUqRm+F9Uo9LvQmZPMdKBn2fkGwIyCYlmusg7Lm4BBEXF7dvklSetk\nj69LahqA9DlsWPb0hZ/Dkj6fJZWvR7sBB0l6DrietK7dJcDqSouvwvvjX/TelCb2rh4Rb9Dxz6ge\nTQemRcTD2fnNpKTTjN+LLwLPRcTrWc3kVmBXYI0m/F6Uq8V34cUl3GOJOnOSWTTRU1J3UrvhkIJj\nWl7+RGoTvbTs2hDg+Oz4eOD2suvHwqIVFt7MqrN3AvtmI5LWJLVZ35lVcf+fpN6SlD33dupQRJwT\nET0jYhPS3+89EXE0cC9p4i6kDt/yz+K47LhyYm+/bJTRxiye2NtpvkPZ3+k0SZtnl/YBJtCE3wtS\nM1kfSStlsS78LJrte1FZq6/Fd6H8HuWf8ZIV3Xn1ETu+WkmjryYD/YuOZzm9p92A+aQRLY+R2ppb\ngbWAkdn7vQtYo+w5A0mjYcYDO5RdPz77bCYBx5Zd3xF4Mnvs0qLfc5Wfy14s7vjfmDT6ZRJpRFG3\n7PqKwA3Z+xoDfLrs+Wdnn9EzwH6d8TsEbEv6Bfg4cAtpVFBTfi+A87K/yydIq7h3a6bvBfB/pNrF\nHFLS/QZpIESu34Wlfd+W9OPJmGZmlpvO3FxmZmZ1zknGzMxy4yRjZma5cZIxM7PcOMmYmVlunGTM\nzCw3TjLWNCStnS0L/09J4ySNktS3BvddXdKrZeefl7RA0vrZ+WqSXss7DrMiOMlYM7kNKEXEphGx\nM2km9waVhbKlR5abiHgLmClpy+zS50mTbHfNzvuQJgmaNRwnGWsKkvYG5kTEHxdei4hpEfG77PHj\nJN0u6W7SjGYk/UJp47jxkg7Prq0r6b5sJeQnJO2mtKna1dn5eEmntRPCgyxOKruSVpcuP38we/2T\nJD0k6TGlDcpWyq5vorTh1nhJP5E0q+y9fT97zuOSzluOH5vZR+YkY82iF6n2sDTbAwdHxBckHQxs\nExFbk9Z0+kW2MODXgeGRVkLelrTEy3ZAj4jYJiK2Ba5u57XLk8zGwI3Aztn5rsCo7PjmiOgdEduT\n9u44Mbt+KXBx9vrTWbz1wb7AZhHRO4t/J0m7V/eRmOXPScaakqSB2f/8x5Zdvitr2oK08+D1ABHx\nMlAiJYVxwAmSfkRKQm+TdmncWNKlkvYHZvFBo4Ddsj2Cno+IuVkcq5DWiXooK7e1pPuVttX9Oik5\nQmpiuyk7/r+y192PtMjho6QkugWwWUc/D7O8OMlYs5hA+mUOQEScSlq9t3zTpbfLjtvbg4OI+Aew\nB2mDpz9LOjoi3iTVakrAt4ArK28eEf8kLWD4FWB0dvkR0sKGz0XEO9m1PwMnR8Q2wI+BlRa+xBJi\nE3B+ROwQEdtHxOYR0V5NyqwQTjLWFCLiHmBFSd8qu7zKUp5yP3BE1t/yKVJieUhST+CViLiKlEx2\nyHZZ7BoRtwL/S2q2as9o4DQWJ5kxwOlk/TGZVUl7dnQDjiq7PgY4NDvuV3b9TlLNahUASetn8ZrV\nhRWKDsCshr4KXCLpB8ArpJrLD9orGBG3ZntvjAcWAGdGxMuSjgXOlDSP1Cx2LGmE2tXZhllB2rGy\nPaNIOzgu3HhsNKl/ZlRZmf8lNZ29TFq2/uPZ9e8B10o6h5RY3srivCsbtTY6bf3BLODo7P2ZFc5L\n/Zt1ApJWjoh3s+MjgH4R8bWCwzJbJtdkzDqHHSUNJPXBvAGcUHA8ZlVxTcbMzHLjjn8zM8uNk4yZ\nmeXGScbMzHLjJGNmZrlxkjEzs9w4yZiZWW7+PwgGRWlN9iPzAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<matplotlib.figure.Figure at 0x7fad846ac610>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "plt.plot(gross_wage, average_rate)\n",
     "plt.ylabel(\"Averate Tax Rate\")\n",
@@ -267,10 +157,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "marginal_rate =  (income_tax[:-1] - income_tax[1:]) / (gross_wage[:-1] - gross_wage[1:] ) "
@@ -278,32 +166,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.text.Text at 0x7fad8462d710>"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZkAAAEPCAYAAACQmrmQAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3Xm4XXV97/H3J3PIycRcgTDcIIMFGWQQHI4MEqsSpbXG\nVonDbem1XCytFtpKSdB7LXq9lZaivfciUkHjBIJUGRQO9GGIYaaQkAAaEsKYhAxkOjn53j9+a+es\n7Jxhn5y9zt7r7M/rec5z9pq/e5219/f8hvVbigjMzMyKMKLRAZiZ2fDlJGNmZoVxkjEzs8I4yZiZ\nWWGcZMzMrDBOMmZmVpjCk4ykGZIWSVos6aIelp8n6XFJj0i6R9Lh2fwDJW2Q9HD2c1XRsZqZWX2p\nyPtkJI0AFgOnAyuABcCsiFiUW6ctItZnrz8IfDYi3ifpQOBnEXF0YQGamVmhii7JnAgsiYilEdEJ\nzANm5leoJJhMG7AtN62C4zMzswIVnWT2A5blppdn83Yg6bOSngH+Abggt+ggSQ9JukvSO4oN1czM\n6q3oJNNTSWSn+rmIuCoipgMXAZdks18EpkXE8cBfAd+T1FZYpGZmVnejCt7/cmBabnp/UttMb34A\nfAsgIrYAW7LXD0t6Fngz8HB+A0kefM3MbBdEROFNEkWXZBYA07OeYmOAWcDN+RUkTc9NfoDUUQBJ\ne2YdB5B0CDAdeK6ng0SEfyK49NJLGx5Ds/z4XPhc+Fz0/TNUCi3JRESXpPOB20kJ7eqIWChpLrAg\nIm4Bzpd0BqnUshqYnW3+LuAySZ1AF3BeRLxeZLxmZlZfRVeXERG3AodVzbs09/ovetnuBuCGYqMz\nM7Mi+Y7/YaS9vb3RITQNn4tuPhfdfC6GXqE3Yw4FSVH292BmNtQkEcOg4d/MzFqYk4yZmRXGScbM\nzArjJGNmZoVxkjEzs8I4yZiZWWGcZMzMrDBOMmZmVhgnGTMzK4yTjJmZFcZJxszMCuMkY2ZmhXGS\nMTOzwjjJmJlZYZxkzMysME4yZmZWGCcZMzMrjJOMmZkVxknGzMwK4yRjZmaFcZIxM7PCFJ5kJM2Q\ntEjSYkkX9bD8PEmPS3pE0j2SDs8t+xtJSyQtlPTeomM1MxtONm6EZcvgscfgrrvghReGPgZFRHE7\nl0YAi4HTgRXAAmBWRCzKrdMWEeuz1x8EPhsR75N0JHA9cAKwP/BL4NCoClhS9Swzs5a3di0ccgiM\nGwe77w577AF/93dwxhlpuSQiQkXHMarg/Z8ILImIpQCS5gEzge1JppJgMm3Atuz12cC8iNgK/FbS\nkmx/8wuO2cys9O67D373d6Gjo7FxFJ1k9gOW5aaXkxLFDiR9FvhLYDRwWm7b+3OrvZDNMzOzftx9\nN7z73Y2Oovgk01NRbKe6rYi4CrhK0izgEuCTtW4LMGfOnO2v29vbaW9vH3ikZmbDyD33wGWXdU93\ndHTQ0YBiTdFtMicDcyJiRjZ9MRARcXkv6wtYHRFTqteVdCtwaUTMr9rGbTJmZjkbNsDee8PLL8OE\nCT2vM1RtMkX3LlsATJd0oKQxwCzg5vwKkqbnJj9A6ihAtt4sSWMkHQxMB35dcLxmZqX3wANw9NG9\nJ5ihVGh1WUR0STofuJ2U0K6OiIWS5gILIuIW4HxJZwBbgNXA7GzbpyT9EHgK6CT1OnORxcysH/fc\nA+96V6OjSAqtLhsKri4zM9vRaafB5z8Pv/d7va8zVNVlTjJmZsPI5s3pnpgXXoDJk3tfb7i0yZiZ\n2RB68EE47LC+E8xQcpIxMxtGmqk9BpxkzMyGlWa5CbPCbTJmZsPE1q1pnLLnnoM99+x7XbfJmJnZ\ngDz6KEyb1n+CGUpOMmZmw8SDD8LJJzc6ih05yZiZDRMvvgj7Ndkwwk4yZmbDxCuvwD77NDqKHTnJ\nmJkNEy+/7CRjZmYFefnlNPpyM3GSMTMbJlySMTOzwrhNxszMCrFxI2zZApMmNTqSHTnJmJkNA5X2\nGBV+D//AOMmYmQ0DzdgeA04yZmbDQjO2x4CTjJnZsNCM3ZfBScbMbFhwdZmZmRXGScbMzArjJGNm\nZoV55RW3yZiZWUFatiQjaYakRZIWS7qoh+UXSnpS0qOS7pB0QG5Zl6SHJT0i6adFx2pmVlbNmmQU\nEcXtXBoBLAZOB1YAC4BZEbEot867gfkRsUnSnwHtETErW7Y2IvocJEFSFPkezMyaXWcn7LYbbNoE\nI0fWto0kIqLw8QGKLsmcCCyJiKUR0QnMA2bmV4iIuyNiUzb5AJB/rluTDZBgZtZ8Xn0V9tij9gQz\nlIpOMvsBy3LTy9kxiVT7DPCL3PRYSb+WdJ+kmb1tZGbWypq1qgxgVMH776kk0mPdlqSPA8cD787N\nnhYRL0k6GLhT0uMR8ZvqbefMmbP9dXt7O+3t7YOJ2cysVGpJMh0dHXR0dAxJPHlFt8mcDMyJiBnZ\n9MVARMTlVeudAVwBvCsiVvayr2uAn0XEDVXz3SZjZi3t2mvhjjvguutq32a4tMksAKZLOlDSGGAW\ncHN+BUnHAt8Czs4nGElTsm2QtCdwCvBUwfGamZVOsw6OCQVXl0VEl6TzgdtJCe3qiFgoaS6wICJu\nAb4KTAB+JEnA0oj4EHAE8K+SurJtv5LvlWZmZkkzt8nUVF2WlSimRcQzxYc0MK4uM7NW94lPwBln\nwOzZtW/TNNVlkt4PPAHckU0fI+nGogMzM7PaNOsw/1Bbm8xlwEnA6wAR8SgwvcigzMysds3cJlNL\nkumMiNer5rl+ysysSTRzm0wtDf8LJf0hMCK7X+VzpDvzzcyswbZtg9deg732anQkPaulJHM+6SbJ\nbcANwCZSojEzswZbuRImToQxYxodSc9qKcmcFREXAdtHUJZ0DinhmJlZAzVzewzUVpL5Yg/z/q7e\ngZiZ2cA1c3sM9FGSkXQWMAPYT9L/zi2aRKo6MzOzBmvm7svQd3XZK8B/ktpgnszNXwdcXGRQZmZW\nm9KWZCLiEeARSdfnnvdiZmZNZDi0yewnaZ6kx7NHKC+WtLjwyMzMrF+lLcnkfAf4MvC/gPcBn8I3\nY1oT2LYN1q2DLVu6540cmbpzjh6943pvvAFdXWlZ/umBXV2wfn2aN2ECKDeS05Ytadn48TBuXPey\niPSY240boa1tx66jEWmbrVvTsUaN2vlYI0ak7fLH6uxMy8aN2/FYAJs3w4YNKb6ejrVxY5qW0k9b\nW9pHfr2NG1PM1fH2d27Wrk3z2tpS3AOJt61tx79DRJrf2bnzsbZt6z43Pf0d1q2DsWN3XrZ5c9pu\nW66VeNy4nc/vli3pfY4fn/ZTy9+yElPl3Az2b1k5VuXcjB1b+7lZt677b1v9d1ixornbZPodIFPS\nQxFxvKQnIuKobN6DEfG2IYmwHx4gs/Wceio88UT60pgwYccP69at6QM5Zkz6sG7enKbHj08f3PXr\n07PQJ0xI21e+vLu60rqV+w3Wrk37amtLX0DbtsGkSemDvmZN+qCPH9+doCZOTB/46mONH5/2sWFD\nOt5uu3V/6U+cmGKvJMq2thTD1q3pWCNGpDgi0nZvvJH2O2lS97HGjk3LKvJfSJMmpW3XrEnbjR+f\nlo0enZb1dm7a2tLrDRtSjF1d3a/HjUsx9RSvlJZB2ucbb6Rj5c/N2LHpy7pybiZMSPvesGHHc1P5\nEl63rvuLd/PmdNxJk1K8lXPT1tb9pZxPGpW/5bp1KcYJE9L8CJg8Oa2f/1vmz00lsY0bl+KtnKe2\nth2vm23bev9bbtqUzl3lb9nbdVO5ZqvPTf66mTChOxFV/omoHGvqVLjnHjjiiIF9joZqgMxaSjKb\nsyH4n5X0Z8ALwMRiwzLr2aZN8OCDqYqg8uGtVvkwrl2bPoyVLyXo/u+08sHN/2dY+bBv3py2GT++\n+7/QzZvTlwSkL6hKYqt8qa1d253YKv/xVkoJ69f3fqxNm9Kxdtut+1hbtqT9dXWlY1VKJfljVb68\n8yWF6vO0Zk3aZ3W8GzemfYwdu3O869enn7a2neNdu7b73FTHu25ddyKu5dxEdJ+bSmLLH2v9+u5z\nk/87dHam91U5N/lSSV7l/FaSUr5E0dffsnLdjB2btsvHWzk3A/lbVhL5tm07H6sSR2/Xzbp1aV/5\nkk1XV5q/cePOx2pWtZRkTiI9LGwq8D+AycDlEXFv8eH1zyWZ1vLss2lI89/s9BBuMxuIpinJRMT8\n7OU64BMAkvYvMiiz3ixfDgcc0OgozKxWffYuk3SCpA9ljz9G0lsk/RseINMaZNky2N//4piVRq9J\nRtJXgOuBPwZulTQHuAt4DHjzkERnVsUlGbNy6au6bCbw1ojYKGl3YBlwVEQ8NzShme1s+XI47LBG\nR2FmteqrumxTRGwEiIhVwGInGGs0V5eZlUtfJZlDJFWG8xdwcG6aiDin0MjMeuDqMrNy6SvJ/H7V\n9JVFBmJWC5dkzMql3/tkmp3vk2kdmzalG9o2buz5Jkwzq91Q3SdT+EdV0gxJi7KBNS/qYfmFkp6U\n9KikOyQdkFs2O9vuaUnnFh2rNbcVK+BNb3KCMSuTWoaV2WWSRpCq2U4HVgALJN0UEYtyqz0MHB8R\nm7Jha74GzJI0Ffh74DhSm9BD2bZrioy5bC65BB54IA1TUa0yTMi6demnMu7VxIlw9tlwccmeCuSq\nMrPy6TfJSBobEZur5u2e9Tjrz4nAkohYmm03j9Q1enuSiYi7c+s/QLovB+As4PZKUpF0O+lJnT+o\n4bgt48Yb4YIL4OCDdx7DqDJq68SJ3QMdrl0L8+fDt79dviTjRn+z8qmlJLNA0mciYgGApJnAV4Fa\n7lbYj3R/TcVyUuLpzWeAX/Sy7QvZPMvZsAFOOw2mT699m9Gj4etfLy6morgkY1Y+tSSZc4FvS7oN\neBPpi/7MGvffU6NSj630kj4OHA+8e6DbzpkzZ/vr9vZ22tvbawyv/CpDpA/ElCnw+uvFxFOk5cvh\nzR5rwmyXdHR00NHRMeTHral3maSzge+RBsk8tdabMiWdDMyJiBnZ9MVARMTlVeudAVwBvCsiVmbz\nZgHtEfFn2fS3gLsi4gdV27Z077LJk2Hp0pQ4arVpU1p/U8keqv2hD8Hs2fDhDzc6ErPya5reZZL+\nFfgCcAypOuvnks6rcf8LgOmSDpQ0BpgF3Fy1/2OBbwFnVxJM5jbgTEmTs04AZ2bzLGdXSjKV55NU\nnqhYFq4uMyufWjqDPkMqYTwTET8HTgZOqWXnEdEFnA/cDjwJzIuIhZLmSvpAttpXgQnAjyQ9Iumn\n2bargS8BDwLzgbkRUcJKnuJ0dqZeZb09uKovZawyW77cScasbHwzZomtWZN6W1UeeTsQRxwBN9ww\n8Ee2NkrliYy+EdOsPprmoWWS/gvpiZhHAuMq8yPCTbANtitVZRVTpsDq1fWNp0gvvAC/8ztOMGZl\nU8tH9jvANaTeXu8DfojvVWkKGzem55/virJVl/keGbNyqiXJ7BYRtwFExLMR8UVSsrEGG0xJZurU\ncpVk3OhvVk613CezWZKAZ7NhX14AJhYbltVisNVlZSvJOMmYlU8tSeZCoA24gNQ2Mwn4dJFBWW0G\nW5IpW5I59NBGR2FmA9VrdZmk/wkQEfMjYl1EPB8Rn4iImRFx79CFaL1ppYZ/V5eZlVNfbTIzhiwK\n2yWuLjOzZtdXddnI7E77HvtR1zgKsxVoML3LylZdtmyZe5eZlVFfSeZw4CF6H6jykEIispq1SnXZ\n5s0pIe69d6MjMbOB6ivJPBURxw5ZJDZgrVJdtmJFuhFz5MhGR2JmA+X7p0usVe6TcaO/WXn1lWSu\nGLIobJe0SknmpZdg330bHYWZ7Ypek0xEfGcI47BdMJgkM3lyGlhz27b6xlSElSthjz0aHYWZ7QpX\nl5XYYHqXjRqVEtS6dfWNqQirVjnJmJWVk0yJDaYkA+WpMlu5EnbfvdFRmNmu6LV3maR/JnVV7lFE\nXFBIRFazwSaZSuP/gQfWL6YirFoFRx3V6CjMbFf01YX5wSGLwnZJK5VkXF1mVk69JpmIuHYoA7GB\na5Uks2qVq8vMyqqWJ2PuBVzEzk/GPK3AuKwGGzfWp7qs2bkkY1ZetTT8Xw8sBA4G5gK/BRYUGJPV\naMOGXe9dBuUpybjh36y8akkye0TE1UBnRNwdEZ8GXIppAq1QXbZtWyptOcmYlVMtSaYz+/2ipPdL\nOhbwR74J1Kt3WTNbuza9x9GjGx2Jme2KWp6M+WVJk4G/Av6Z9GTMCwuNymrSCiUZ34hpVm79lmQi\n4paIWBMR/xkR74mI4yPi5loPIGmGpEWSFku6qIfl75T0kKROSedULeuS9LCkRyT9tNZjtopWKMm4\nPcas3GrtXfYnwEH59bO2mf62HQFcCZwOrAAWSLopIhblVlsKzAY+38Mu3oiI4/o7Tivq7ISIwVUj\nuSRjZkWrpbrsJuA/gF8CXQPc/4nAkohYCiBpHjAT2J5kIuL5bFlPowv0+FRO6x63TIM4Q2VIMi7J\nmJVbLUlmt4jYqZqrRvsBy3LTy0mJp1ZjJf0a2ApcHhE37WIcw85gq8qgHNVlLsmYlVstSeYWSb8X\nET/fhf339ujmWk2LiJckHQzcKenxiPhN9Upz5szZ/rq9vZ329vaBxlk69UgyZSnJOMmYDV5HRwcd\nHR1DftxakszngL+VtJnUnVlARMSkGrZdDkzLTe9PapupSUS8lP3+jaQO4FigzyTTKuqRZNraYNOm\n1L7TrF2EV66EQw5pdBRm5Vf9D/jcuXOH5Li19C6bGBEjImJ8REzKpmtJMJBGBpgu6UBJY4BZQF89\n07aXfCRNybZB0p7AKcBTNR532BvskDKQ2nOavTTj6jKzcutrqP/DI2KRpB57d0XEw/3tPCK6JJ0P\n3E5KaFdHxEJJc4EFEXGLpLcBNwJTgA9ImhMRRwFHAP8qqSvb9itVvdJaWj1KMtCdZPbaa/D7KoIb\n/s3Kra/qsr8E/hT4eg/LghqHlomIW4HDquZdmnv9IHBAD9vdDxxdyzFa0WDHLauYMqW5G/9dkjEr\nt76G+v/T7Pd7hi4cq1W9SjJTpzZ3dZlLMmblVsvNmOf0MHsN8EREvFL/kKwW9a4ua1YuyZiVWy29\nyz4DvB24K5tuBx4CDpZ0WUR8t6DYrA/1LMk0a3VZV1caIHPKlEZHYma7qpYkMwo4IiJeBpC0D/Bv\nwEnAPYCTTAPUo3cZNHdJZvVqmDQJRo5sdCRmtqtqGer/gEqCybySzVtF92MAbIjVs7qsWUsyrioz\nK79aSjIdkm4BfpRN/342bwLQpP8DD3/1rC57/vnB76cIbvQ3K79aksyfA+cA7yDdLPlvwE8iIgD3\nPGuQDRtSghisZq4uc0nGrPz6TDKSRgK/zLox/2RoQrJatEJ1mUsyZuXXZ5tMRHQB27InY1oTqVfD\nfzPfJ+OSjFn51VJdth54QtIdwBuVmRFxQWFRWb9a4T4Zl2TMyq+WJHND9mNNpBXuk1m5Eo48stFR\nmNlg9JtkIuLaoQjEBqZeSWby5FSSiRjcUzaLsGqVSzJmZVfLsDKHAl8BjgTGVeZHhJ/y0UD1GiBz\n3Lh0s+OGDTBhwuD3V09+YJlZ+dVyM+Y1wDdJj0B+D6kL83VFBmX9q1dJBtIX+StNOAqdG/7Nyq+W\nJDM+In4FKCKWRsQc4P3FhmX9qVfvMoC3vx3uvrs++6onN/yblV8tSWaTpBHAEknnS/ow0FZwXNaP\nepZkZsyA226rz77qySUZs/JTunG/jxWkE4CFpCdXfgmYDHw1Ih4oPrz+SYr+3sNwNGUK/Pa39Rmh\nePlyOOYYePnl5hmMcsuW1Ea0ZUvzdUgwGw4kERGFf7pq6V22IHu5HvhUseFYrepZktl/f9hnH3j4\nYTjhhPrsc7BWr07dq51gzMqt1yQj6ea+NoyIs+sfjtVi69b0rJXRo+u3z7POSlVmzZJk3B5jNjz0\nVZJ5O7AM+D4wnzQ4pjWBSqN/Pf/LnzEDLrsMvvjF+u1zMNx92Wx46CvJ7AucCXwM+CPg34HvR8ST\nQxGY9a6eVWUV73wnPP44rFmTbtBsNN+IaTY89Nq7LCK6IuLWiJgNnAw8Q3qOzH8fsuisR0UkmfHj\n4ZRT4Fe/qu9+d5VLMmbDQ59dmCWNlXQO6ebLPwf+CY9j1nBFJBnobpdpBu6+bDY89JpkJF0L3Acc\nB8yNiBMi4ksR8cJADiBphqRFkhZLuqiH5e+U9JCkziyh5ZfNzrZ7WtK5AznucFZUkqncL9MMPcLd\n8G82PPRVkvkE8Gbgc8B9ktZmP+skra1l59lNnFcCZwFvAT4m6fCq1ZYCs4Hrq7adCvw9cAJwEnCp\nn2uT1GvcsmqHHw7btsHTT9d/3wPlkozZ8NBrw39E1DIaQH9OBJZExFIASfOAmcCi3HGez5ZV//98\nFnB7RKzJlt8OzAB+UIe4Sq2eQ8rkSak085GPpHtUNm9O3aXHjIGxY9Pv3m7WjEjrb9mSfktpm7Fj\nU1fr3nrCbd2a1q8ca/TotM3TT8MZZ9T/PZrZ0KrleTKDsR+pG3TFclLi2ZVtX8jmtbyiqssAvvxl\nePTR7gQxciR0dnYngr6q0irbjBnTnXQ2b07b92bkyO7tRo3qPlZnJ7zjHfV/f2Y2tIpOMj39/1pr\njX/N286ZM2f76/b2dtrb22s8RDkVmWT23hve+95i9m1mjdPR0UFHR8eQH7foJLMcmJab3h9YMYBt\n26u2vaunFfNJphUUmWTMbHiq/gd87ty5Q3LcerS79GUBMF3SgZLGALOAvoaryZdebgPOlDQ56wRw\nZjav5TnJmFlZFJpkIqILOB+4HXgSmBcRCyXNlfQBAElvk7QM+APgW5KeyLZdTRr1+UHSsDZzI+L1\nIuMti6J6l5mZ1Vu/Q/03u1Yc6v+SS1Lj+iWXNDoSMyuroRrqv+jqMiuAq8vMrCycZErIScbMysJJ\npoScZMysLJxkSshJxszKwkmmhDZudO8yMysHJ5kScknGzMrCSaaEnGTMrCycZErIScbMysJJpoSc\nZMysLJxkSshJxszKwkmmhIp6aJmZWb05yZSQB8g0s7JwkimZrVu7H4lsZtbsnGRKplJVpsLHTjUz\nGzwnmZJxo7+ZlYmTTMm40d/MysRJpmTc6G9mZeIkUzKrVsHUqY2OwsysNk4yJfPaa7Dnno2Owsys\nNk4yJfPqq7DXXo2OwsysNk4yJfPaa04yZlYeTjIl8+qrri4zs/JwkikZV5eZWZkUnmQkzZC0SNJi\nSRf1sHyMpHmSlki6X9K0bP6BkjZIejj7uaroWMvA1WVmViajity5pBHAlcDpwApggaSbImJRbrXP\nAKsi4lBJHwW+CszKlj0TEccVGWPZuLrMzMqk6JLMicCSiFgaEZ3APGBm1TozgWuz1z8mJaQKj9BV\nxdVlZlYmRSeZ/YBluenl2bwe14mILuB1Sbtnyw6S9JCkuyS9o+BYS8H3yZhZmRRaXUbPJZHoZx1l\n67wITIuI1ZKOA34q6ciIWF+9wzlz5mx/3d7eTnt7+2BiblobNsC2bTBhQqMjMbOy6ejooKOjY8iP\nq4jq7/w67lw6GZgTETOy6YuBiIjLc+v8IltnvqSRwIsRsXcP+7oL+KuIeLhqfhT5HprJ0qXwznfC\n8883OhIzKztJREThTRJFV5ctAKZnPcXGkBr0b65a52fA7Oz1R4A7ASTtmXUcQNIhwHTguYLjbWqu\nKjOzsim0uiwiuiSdD9xOSmhXR8RCSXOBBRFxC3A18F1JS4CVdPcsexdwmaROoAs4LyJeLzLeZudG\nfzMrm0Kry4ZCK1WXffe7cNttcN11jY7EzMpuuFSXWR25uszMysZJpkRcXWZmZeMkUyIeUsbMysZJ\npkQ8pIyZlY2TTIm4uszMysZJpkRcXWZmZeMkUyKuLjOzsvF9MiWxdSuMHw+bN8MI/2tgZoPk+2Rs\nB6tWwdSpTjBmVi7+yioJV5WZWRk5yZSEe5aZWRk5yZSEh5QxszJykikJl2TMrIycZErCScbMyshJ\npiRcXWZmZeQkUxIuyZhZGTnJlISHlDGzMnKSKQnfJ2NmZeQkUxKuLjOzMvLYZSUQAePGwZo16beZ\n2WB57DLbbt06GDPGCcbMysdJpgRcVWZmZVV4kpE0Q9IiSYslXdTD8jGS5klaIul+SdNyy/4mm79Q\n0nuLjrVZuWeZmZVVoUlG0gjgSuAs4C3AxyQdXrXaZ4BVEXEo8A3gq9m2RwJ/CBwBvA+4SlLh9YfN\nqNaeZR0dHYXHUhY+F918Lrr5XAy9oksyJwJLImJpRHQC84CZVevMBK7NXv8YOC17fTYwLyK2RsRv\ngSXZ/lpOrdVl/gB187no5nPRzedi6BWdZPYDluWml2fzelwnIrqANZJ272HbF3rYtiW4uszMympU\nwfvvqXqrur9xb+vUsi0AH/zgAKMqmUWL4E/+pNFRmJkNXKH3yUg6GZgTETOy6YuBiIjLc+v8Iltn\nvqSRwIsRsXf1upJuBS6NiPlVxxjeN8mYmRVkKO6TKbokswCYLulA4EVgFvCxqnV+BswG5gMfAe7M\n5t8MXC/pH0nVZNOBX1cfYChOkpmZ7ZpCk0xEdEk6H7id1P5zdUQslDQXWBARtwBXA9+VtARYSUpE\nRMRTkn4IPAV0Ap8d9rf2m5kNM6UfVsbMzJpXqe/47+9GzzKStL+kOyU9JekJSRdk86dKul3S05Ju\nkzQ5t80/ZTetPirpmNz82dm5eVrSubn5x0l6PFv2jaF9hwMnaYSkhyXdnE0fJOmB7H19X9KobP6A\nb+wt0zUkabKkH2Xv4UlJJ7XqdSHpQkn/mcV7ffa3b5nrQtLVkl6W9HhuXuHXQl/H6FVElPKHlCCf\nAQ4ERgOPAoc3Oq46vK99gWOy123A08DhwOXAX2fzLwL+IXv9PuDfs9cnAQ9kr6cCzwKTgSmV19my\n+cCJ2eufA2c1+n33c04uBK4Dbs6mfwB8JHv9TeC87PV/A67KXn+UdJ8VwJHAI6Tq4YOy60Zlu4aA\n7wCfyl6Pyv62LXddAG8CngPG5K6H2a10XQDvAI4BHs/NK/xa6O0Yfcba6JM1iJN8MvCL3PTFwEWN\njquA9/nqPhdsAAAGYklEQVRT4AxgEbBPNm9fYGH2+lvAR3PrLwT2IbVtfTM3/5vZB2xf4Knc/B3W\na7YfYH/gDqCd7iTzKjCi+joAbgVOyl6PBF7p6doAfpF92EpzDQETgWd7mN9y1wUpySzNviRHkToJ\nnQm80krXBSkJ5pNM4ddCD8dY1F+cZa4uq+VGz1KTdBDpv5UHSH/YlwEi4iVg72y13s5Dbzez7pet\nU71+s/pH4Atk90hJ2gNYHRHbsuX5+Ad6Y2+ZrqFDgNckXZNVHf4fSbvRgtdFRKwAvg48T4p/DfAw\n8HoLXhd5ew/BtVB9vfV7m3iZk0zNN2uWkaQ20jA7n4uI9fT+3qrPg+j7ZtbSnDdJ7wdejohH6Y5b\n7PweIres2rA4F6T/2I8D/iUijgPeIP2H3YrXxRTScFQHkko1E0hVQtVa4bqoRUOvhTInmeXAtNz0\n/sCKBsVSV1mD5Y+B70bETdnslyXtky3fl1Q1AOk8HJDbvHIeejs/va3fjE4Fzpb0HPB90rh23wAm\nKw2+CjvGv/29Kd3YOzkiVjPwc9SMlgPLIuLBbPonpKTTitfFGcBzEbEqK5ncCJwCTGnB6yJvKK6F\nl3o5Rq/KnGS23+gpaQyp3vDmBsdUL98m1YlekZt3M/DJ7PUngZty88+F7SMsvJ4VZ28Dzsx6JE0l\n1VnflhVx10o6UZKybW+iCUXE30bEtIg4hPT3vTMiPg7cRbpxF1KDb/5czM5eV9/YOyvrZXQw3Tf2\nluYayv6myyS9OZt1OvAkLXhdkKrJTpY0Lou1ci5a7bqoLtUPxbWQP0b+HPeu0Y1Xg2z4mkHqfbUE\nuLjR8dTpPZ0KdJF6tDxCqmueAewO/DJ7v3cAU3LbXEnqDfMYcFxu/iezc7MYODc3/3jgiWzZFY1+\nzzWel3fT3fB/MKn3y2JSj6LR2fyxwA+z9/UAcFBu+7/JztFC4L1lvIaAt5K+AB8FbiD1CmrJ6wK4\nNPtbPk4axX10K10XwPdIpYvNpKT7KVJHiEKvhb6ut95+fDOmmZkVpszVZWZm1uScZMzMrDBOMmZm\nVhgnGTMzK4yTjJmZFcZJxszMCuMkYy1D0t7ZsPDPSFog6V5JM4fguJMlvZabfrukbZLelE1PkrSy\n6DjMGsFJxlrJT4GOiJgeESeQ7uTev3qlbOiRuomINcCLkg7PZr2ddJPtKdn0yaSbBM2GHScZawmS\nTgM2R8T/rcyLiGUR8S/Z8tmSbpL0K9IdzUj6mtKD4x6T9IfZvH0l3Z2NhPy4pFOVHqp2TTb9mKTP\n9RDCfXQnlVNIo0vnp+/L9v9fJf1a0iNKDygbl80/ROmBW49J+pKkdbn39vlsm0clXVrH02Y2aE4y\n1ireQio99OVY4JyIeI+kc4CjI+Io0phOX8sGBvwj4NZIIyG/lTTEyzHAfhFxdES8Fbimh33nk8zB\nwI+AE7LpU4B7s9c/iYgTI+JY0rM7PpPNvwL4x2z/y+l+9MGZwKERcWIW/9skvaO2U2JWPCcZa0mS\nrsz+85+fm31HVrUF6cmD3weIiFeADlJSWAB8WtLfk5LQG6SnNB4s6QpJZwHr2Nm9wKnZM4J+GxFb\nsjgmkMaJ+nW23lGS7lF6rO4fkZIjpCq2H2evv5fb73tJgxw+TEqihwGHDvR8mBXFScZaxZOkL3MA\nIuJ80ui9+YcuvZF73dMzOIiI/wDeSXrA03ckfTwiXieVajqA84D/V33wiHiGNIDhB4H7s9kPkQY2\nfC4iNmTzvgN8NiKOBi4DxlV20UtsAr4SEcdFxLER8eaI6KkkZdYQTjLWEiLiTmCspPNysyf0sck9\nwEez9pa9SInl15KmAa9GxNWkZHJc9pTFkRFxI3AJqdqqJ/cDn6M7yTwA/AVZe0ymjfTMjtHAH+fm\nPwD8QfZ6Vm7+baSS1QQASW/K4jVrCqMaHYDZEPoQ8A1Jfw28Siq5/HVPK0bEjdmzNx4DtgFfiIhX\nJJ0LfEFSJ6la7FxSD7VrsgdmBemJlT25l/QEx8qDx+4ntc/cm1vnElLV2SukYesnZvMvBK6T9Lek\nxLImi/OOrNfa/enRH6wDPp69P7OG81D/ZiUgaXxEbMxefxSYFREfbnBYZv1yScasHI6XdCWpDWY1\n8OkGx2NWE5dkzMysMG74NzOzwjjJmJlZYZxkzMysME4yZmZWGCcZMzMrjJOMmZkV5v8Dcrey6xlN\nBpAAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<matplotlib.figure.Figure at 0x7fad844bf410>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "plt.plot(gross_wage[:-1], marginal_rate)\n",
     "plt.ylabel(\"Marginal Tax Rate\")\n",
@@ -312,22 +177,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(0.22296934, 0.22327389)"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "marginal_rate[40], marginal_rate[95]"
    ]
@@ -355,10 +207,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from openfisca_core.rates import average_rate, marginal_rate"
@@ -366,120 +216,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([    0.        ,   -74.43458557,  -148.8601532 ,  -223.29470825,\n",
-       "        -297.72930908,  -372.15487671,  -446.5894165 ,  -521.02398682,\n",
-       "        -595.45861816,  -669.88427734,  -744.31872559,  -818.7532959 ,\n",
-       "        -893.17883301,  -967.61346436, -1042.04797363, -1116.47363281,\n",
-       "       -1190.9083252 , -1265.34277344, -1339.76855469, -1414.20300293,\n",
-       "       -1488.63745117, -1563.07202148, -1637.49780273, -1711.93237305,\n",
-       "       -1786.36694336, -1860.79248047, -1935.22692871, -2009.66174316,\n",
-       "       -2084.0871582 , -2158.52172852, -2232.95654297, -2307.38134766,\n",
-       "       -2381.81665039, -2456.25048828, -2530.68554688, -2605.11083984,\n",
-       "       -2679.5456543 , -2753.98022461, -2828.40600586, -2902.84008789,\n",
-       "       -2977.27490234, -3051.70068359, -3126.13525391, -3200.56982422,\n",
-       "       -3275.00439453, -3349.43017578, -3423.86474609, -3498.29882812,\n",
-       "       -3572.72412109, -3647.15917969, -3721.59423828, -3796.01904297,\n",
-       "       -3870.45385742, -3944.88867188, -4019.31445312, -4093.74829102,\n",
-       "       -4168.18310547, -4242.61816406, -4317.04345703, -4391.47753906,\n",
-       "       -4465.91308594, -4540.33886719, -4614.77294922, -4689.20654297,\n",
-       "       -4763.63330078, -4838.06738281, -4912.50097656, -4986.92724609,\n",
-       "       -5061.36230469, -5135.796875  , -5210.23046875, -5284.65722656,\n",
-       "       -5359.09130859, -5433.52636719, -5507.95117188, -5582.38623047,\n",
-       "       -5656.82080078, -5731.24707031, -5805.68017578, -5880.11572266,\n",
-       "       -5954.54101562, -6028.97509766, -6103.40966797, -6177.84472656,\n",
-       "       -6252.27050781, -6326.70458984, -6401.13964844, -6475.56542969,\n",
-       "       -6550.        , -6624.43457031, -6698.86035156, -6773.29492188,\n",
-       "       -6847.72949219, -6922.16308594, -6996.58886719, -7071.02392578,\n",
-       "       -7145.45800781, -7219.88378906, -7294.31835938, -7368.75292969], dtype=float32)"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "csg = simulation.calculate('csg')\n",
+    "csg = simulation.calculate('csg', 2014)\n",
     "csg"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([ 0.07369024,  0.07368577,  0.07368726,  0.07368803,  0.07368666,\n",
-       "        0.07368726,  0.07368767,  0.07368803,  0.07368726,  0.07368755,\n",
-       "        0.07368779,  0.07368726,  0.07368749,  0.07368767,  0.07368726,\n",
-       "        0.07368743,  0.07368761,  0.07368726,  0.07368743,  0.07368755,\n",
-       "        0.07368767,  0.07368737,  0.07368755,  0.07368761,  0.07368737,\n",
-       "        0.07368749,  0.07368761,  0.07368737,  0.07368743,  0.07368755,\n",
-       "        0.07368731,  0.07368743,  0.07368749,  0.07368761,  0.07368743,\n",
-       "        0.07368749,  0.07368755,  0.07368743,  0.07368749,  0.07368755,\n",
-       "        0.07368743,  0.07368749,  0.07368755,  0.07368761,  0.07368743,\n",
-       "        0.07368755,  0.07368755,  0.07368743,  0.07368749,  0.07368755,\n",
-       "        0.07368743,  0.07368749,  0.07368755,  0.07368743,  0.07368749,\n",
-       "        0.07368755,  0.07368755,  0.07368743,  0.07368749,  0.07368755,\n",
-       "        0.07368749,  0.07368749,  0.07368755,  0.07368743,  0.07368749,\n",
-       "        0.07368749,  0.07368743,  0.07368749,  0.07368755,  0.07368755,\n",
-       "        0.07368749,  0.07368749,  0.07368755,  0.07368743,  0.07368749,\n",
-       "        0.07368755,  0.07368743,  0.07368749,  0.07368755,  0.07368743,\n",
-       "        0.07368749,  0.07368749,  0.07368755,  0.07368749,  0.07368749,\n",
-       "        0.07368755,  0.07368743,  0.07368749,  0.07368755,  0.07368743,\n",
-       "        0.07368749,  0.07368755,  0.07368755,  0.07368749,  0.07368749,\n",
-       "        0.07368755,  0.07368749,  0.07368749,  0.07368755], dtype=float32)"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "1 - average_rate(-csg[1:], gross_wage[1:])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x7fad7f7b9990>]"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAD7CAYAAAB5aaOHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAADt9JREFUeJzt3X+spFV9x/H3BxbaVCgsDbAVRDS03ZY/pGyCpJoyEZBt\naqRJS4XUshiTmjbWxiZ2F2LCNf7j2jaiodqYaEu1deuPVqiKLAbHf+oKLWxR3F1WTJBVWSmIxiY1\nBr/9Yx52x9u5d891ZmfmMu9XMsnznOfMnPOcOfd+7vMj90lVIUnSsZww6w5IktYHA0OS1MTAkCQ1\nMTAkSU0MDElSEwNDktRkw6w7MCyJ9/hK0k+hqnK825i7I4yq8lXFzTffPPM+zMvLsXAsHIvVX9My\nd4EhSZpPBoYkqYmBMad6vd6suzA3HIujHIujHIvpyzTPfx1Lkpqn/kjSepCEWsSL3pKk+WRgSJKa\nGBiSpCYGhiSpiYEhSWpiYEiSmhgYkqQmBoYkqYmBIUlqYmBIkpoYGJKkJgaGJKnJRAIjydYk+5M8\nnGT7KvV+L8mPk1w8iXYlSdMzdmAkOQG4FbgKuBC4LsnmEfVOAf4U2DNum5Kk6ZvEEcYlwMGqerSq\nfgTsAq4eUe/twE7ghxNoU5I0ZZMIjHOAx4bWD3VlRyS5CDi3qj4zgfYkSTOwYQKfMeqhHUeegpQk\nwLuAbcd4DwBLS0tHlnu9nk/VkqRl+v0+/X5/6u2O/cS9JJcCS1W1tVvfAVRV7ezWfx74GvADBkGx\nCXgSeHVV3b/ss3ziniSt0bSeuDeJwDgROABcDnwbuBe4rqr2rVD/88CfV9UDI7YZGJK0RuvmEa1V\n9QzwRmA38BCwq6r2JXlbkleNegurnJKSJM2nsY8wJskjDElau3VzhCFJWgwGhiSpiYEhSWpiYEiS\nmhgYkqQmBoYkqYmBIUlqYmBIkpoYGJKkJgaGJKmJgSFJamJgSJKaGBiSpCYGhiSpiYEhSWpiYEiS\nmhgYkqQmBoYkqYmBIUlqYmBIkpoYGJKkJgaGJKmJgSFJamJgSJKaGBiSpCYGhiSpiYEhSWpiYEiS\nmhgYkqQmBoYkqYmBIUlqYmBIkpoYGJKkJgaGJKmJgSFJajKRwEiyNcn+JA8n2T5i+5uTPJRkb5K7\nk7xgEu1KkqZn7MBIcgJwK3AVcCFwXZLNy6rdD2ypqouATwB/OW67kqTpmsQRxiXAwap6tKp+BOwC\nrh6uUFVfqKr/7Vb3AOdMoF1J0hRNIjDOAR4bWj/E6oHweuDOCbQrSZqiDRP4jIwoq5EVk9cCW4DL\nJtCuJGmKJhEYh4DzhtbPBb61vFKSK4Abgd/sTl2NtLS0dGS51+vR6/Um0EVJeu7o9/v0+/2pt5uq\nkQcD7R+QnAgcAC4Hvg3cC1xXVfuG6vw68DHgqqp6ZJXPqnH7I0mLJglVNepsz0SNfQ2jqp4B3gjs\nBh4CdlXVviRvS/Kqrto7gecBH0vyQJJPjtuuJGm6xj7CmCSPMCRp7dbNEYYkaTEYGJKkJgaGJKmJ\ngSFJamJgSJKaGBiSpCYGhiSpiYEhSWpiYEiSmhgYkqQmBoYkqYmBIUlqYmBIkpoYGJKkJgaGJKmJ\ngSFJamJgSJKaGBiSpCYGhiSpiYEhSWpiYEiSmhgYkqQmBoYkqcmGWXdgJUtL8IUvzLoXkqRnpapm\n3YcjktSz/fnKV+CJJ2bcIUlaB17xilBVOd7tzG1gSJLaJNMJDK9hSJKaGBiSpCYGhiSpiYEhSWpi\nYEiSmhgYkqQmBoYkqYmBIUlqYmBIkpoYGJKkJhMJjCRbk+xP8nCS7SO2n5xkV5KDSb6Y5LxJtCtJ\nmp6xAyPJCcCtwFXAhcB1STYvq/Z64Kmq+iXgFuCd47YrSZquSRxhXAIcrKpHq+pHwC7g6mV1rgZu\n65Y/Dlw+gXYlSVM0icA4B3hsaP1QVzayTlU9Azyd5IwJtC1JmpJJPEBp1L/UXf4/ypfXyYg6ACwt\nLR1Z7vV69Hq9MbomSc89/X6ffr8/9XbHfh5GkkuBpara2q3vAKqqdg7VubOr86UkJwLfrqqzRnyW\nz8OQpDVaT8/DuA+4IMkLk5wMXAvcsazOvwHbuuVrgHsm0K4kaYrGPiVVVc8keSOwm0EAfaCq9iV5\nG3BfVX0K+ADwoSQHgScZhIokaR3xEa2StM6tp1NSkqQFYGBIkpoYGJKkJgaGJKmJgSFJamJgSJKa\nGBiSpCYGhiSpiYEhSWpiYEiSmhgYkqQmBoYkqYmBIUlqYmBIkpoYGJKkJgaGJKmJgSFJamJgSJKa\nGBiSpCYGhiSpiYEhSWpiYEiSmhgYkqQmBoYkqYmBIUlqYmBIkpoYGJKkJgaGJKmJgSFJamJgSJKa\nGBiSpCYGhiSpiYEhSWpiYEiSmhgYkqQmYwVGko1Jdic5kOSuJKeNqPOSJP+e5MtJ9ib5/XHalCTN\nRqrqp39zshN4sqremWQ7sLGqdiyrcwFQVfVIkl8E/hPYXFXfH/F5NU5/JGkRJaGqctzbGTMw9gOX\nVdXhJJuAflVtPsZ79gK/W1WPjNhmYEjSGk0rMMa9hnFWVR0GqKrHgTNXq5zkEuCkUWEhSZpvG45V\nIcndwNnDRUABb11LQ93pqH8A/nAt75MkzYdjBkZVXbnStiSHk5w9dErqOyvUOxX4FHBTVd23WntL\nS0tHlnu9Hr1e71hdlKSF0u/36ff7U293Ehe9n6qqnatc9D4J+Cxwe1W95xif5zUMSVqj9XLR+wzg\no8ALgG8A11TV00m2AG+oqj9K8gfAB4GHOHo664aqenDE5xkYkrRG6yIwJs3AkKS1Wy93SUmSFoSB\nIUlqYmBIkpoYGJKkJgaGJKmJgSFJamJgSJKaGBiSpCYGhiSpiYEhSWpiYEiSmhgYkqQmBoYkqYmB\nIUlqYmBIkpoYGJKkJgaGJKmJgSFJamJgSJKaGBiSpCYGhiSpiYEhSWpiYEiSmhgYkqQmBoYkqYmB\nIUlqYmBIkpoYGJKkJgaGJKmJgSFJamJgSJKaGBiSpCYGhiSpiYEhSWpiYEiSmhgYkqQmYwVGko1J\ndic5kOSuJKetUvfUJIeSvGecNiVJszHuEcYO4HNV9SvAPcCNq9R9O9Afsz1J0oyMGxhXA7d1y7cB\nvzOqUpItwFnA7jHbkyTNyLiBcVZVHQaoqseBM5dXSBLgr4C3ABmzPUnSjGw4VoUkdwNnDxcBBby1\nsY0/AT5dVd8cZMfqobG0tHRkudfr0ev1GpuRpMXQ7/fp9/tTbzdV9dO/OdkH9KrqcJJNwOer6leX\n1fkw8HLgx8CpwEnAe6vqphGfV+P0R5IWURKq6rifwRk3MHYCT1XVziTbgY1VtWOV+tuALVX1phW2\nGxiStEbTCoxxr2HsBK5McgC4AngHDC5yJ3n/uJ2TJM2PsY4wJs0jDElau/VyhCFJWhAGhiSpiYEh\nSWpiYEiSmhgYkqQmBoYkqYmBIUlqYmBIkpoYGJKkJgaGJKmJgSFJamJgSJKaGBiSpCYGhiSpiYEx\np2bx+MV55Vgc5Vgc5VhMn4Exp/xhOMqxOMqxOMqxmD4DQ5LUxMCQJDWZu0e0zroPkrQeTeMRrXMV\nGJKk+eUpKUlSEwNDktRkbgIjydYk+5M8nGT7rPszCUnOTXJPkq8m+XKSN3XlG5PsTnIgyV1JTht6\nz3uSHEyyN8lFQ+XburE5kOT6ofKLkzzYbbtlunu4dklOSHJ/kju69fOT7On26yNJNnTlJyfZ1Y3F\nF5OcN/QZN3bl+5K8cqh83cyhJKcl+Vi3Dw8leemizoskb07yla6//9h99wszL5J8IMnhJA8OlR33\nubBaGyuqqpm/GATX14AXAicBe4HNs+7XBPZrE3BRt3wKcADYDOwE/qIr3w68o1v+LeDT3fJLgT3d\n8kbgEeA04PRnl7ttXwIu6ZY/A1w16/0+xpi8GfgwcEe3/s/ANd3y+4A3dMt/DLy3W34NsKtb/jXg\nAWADcH43b7Le5hDw98DruuUN3Xe7cPMCeD7wdeDkofmwbZHmBfBy4CLgwaGy4z4XVmpj1b7OerC6\nzl4K3Dm0vgPYPut+HYf9/CRwBbAfOLsr2wTs65b/FnjNUP19wNnAtcD7hsrf1/2wbAK+OlT+E/Xm\n7QWcC9wN9DgaGE8AJyyfB8BngZd2yycC3xk1N4A7ux+cdTOHgFOBR0aUL9y8YBAYj3a/8DYAdwBX\nAt9ZpHnBINCGA+O4z4URbew/Vj/n5ZTUOcBjQ+uHurLnjCTnM/grYg+DL+kwQFU9DpzVVVtpHJaX\nf3Oo/NCI+vPqXcBbgAJI8gvAd6vqx9324f4f2eeqegb4XpIzWH0s1sscejHw30n+rjs99/4kP8cC\nzouq+hbw18A3GPT/e8D9wNMLOC+GnTWFubB8vp15rE7NS2CMun/4OXO/b5JTgI8Df1ZVP2DlfVs+\nDunqrjQ+62bckvw2cLiq9nK03+H/70MNbVvuOTEWDP6Svhj4m6q6GPgfBn/5LuK8OB24msFf2M8H\nnsfgtMtyizAvWsx0LsxLYBwCzhtaPxf41oz6MlHdxbqPAx+qqtu74sNJzu62b2Jw+A2DcXjB0Nuf\nHYeVxmel+vPoZcCrk3wd+AjwCuAW4LQkz87D4f4f2bckJzI4H/td1j5G8+gQ8FhV/Ue3/gkGAbKI\n8+IK4OtV9VR3xPCvwG8Apy/gvBg2jbnw+AptrGheAuM+4IIkL0xyMoPzbHfMuE+T8kEG5xDfPVR2\nB3BDt3wDcPtQ+fUASS5lcFh+GLgLuLK7s2Yjg3O8d3WHkd9PckmSdO+9nTlUVTdV1XlV9WIG3+89\nVfVa4PPANV21bfzkWGzrlq8B7hkqv7a7W+ZFwAXAvayjOdR9p48l+eWu6HLgIRZwXjA4FXVpkp/t\n+vrsWCzavFh+tD2NuTDcxvAYr2zWF3uGLsZsZXAX0UFgx6z7M6F9ehnwDIM7Mx5gcG52K3AG8Llu\nf+8GTh96z60M7ur4L+DiofIburF5GLh+qHwL8OVu27tnvc+N43IZRy96v4jBXRwPM7gz5qSu/GeA\nj3b7tQc4f+j9N3ZjtA945XqcQ8BLGPwy2wv8C4O7WxZyXgA3d9/lg8BtDO5mWph5AfwTg7/6f8gg\nQF/H4CaA4zoXVptvK7381yCSpCbzckpKkjTnDAxJUhMDQ5LUxMCQJDUxMCRJTQwMSVITA0OS1MTA\nkCQ1+T8oQkpyiwXK4wAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<matplotlib.figure.Figure at 0x7fad7f7b9c90>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "plt.ylim(-0.5,0.5)\n",
     "plt.plot(gross_wage[1:], 1-average_rate(-csg[1:], gross_wage[1:]))"
@@ -487,32 +245,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(-0.5, 0.5)"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAD7CAYAAAB5aaOHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAADt9JREFUeJzt3X+spFV9x/H3BxbaVCgsDbAVRDS03ZY/pGyCpJoyEZBt\naqRJS4XUshiTmjbWxiZ2F2LCNf7j2jaiodqYaEu1deuPVqiKLAbHf+oKLWxR3F1WTJBVWSmIxiY1\nBr/9Yx52x9u5d891ZmfmMu9XMsnznOfMnPOcOfd+7vMj90lVIUnSsZww6w5IktYHA0OS1MTAkCQ1\nMTAkSU0MDElSEwNDktRkw6w7MCyJ9/hK0k+hqnK825i7I4yq8lXFzTffPPM+zMvLsXAsHIvVX9My\nd4EhSZpPBoYkqYmBMad6vd6suzA3HIujHIujHIvpyzTPfx1Lkpqn/kjSepCEWsSL3pKk+WRgSJKa\nGBiSpCYGhiSpiYEhSWpiYEiSmhgYkqQmBoYkqYmBIUlqYmBIkpoYGJKkJgaGJKnJRAIjydYk+5M8\nnGT7KvV+L8mPk1w8iXYlSdMzdmAkOQG4FbgKuBC4LsnmEfVOAf4U2DNum5Kk6ZvEEcYlwMGqerSq\nfgTsAq4eUe/twE7ghxNoU5I0ZZMIjHOAx4bWD3VlRyS5CDi3qj4zgfYkSTOwYQKfMeqhHUeegpQk\nwLuAbcd4DwBLS0tHlnu9nk/VkqRl+v0+/X5/6u2O/cS9JJcCS1W1tVvfAVRV7ezWfx74GvADBkGx\nCXgSeHVV3b/ss3ziniSt0bSeuDeJwDgROABcDnwbuBe4rqr2rVD/88CfV9UDI7YZGJK0RuvmEa1V\n9QzwRmA38BCwq6r2JXlbkleNegurnJKSJM2nsY8wJskjDElau3VzhCFJWgwGhiSpiYEhSWpiYEiS\nmhgYkqQmBoYkqYmBIUlqYmBIkpoYGJKkJgaGJKmJgSFJamJgSJKaGBiSpCYGhiSpiYEhSWpiYEiS\nmhgYkqQmBoYkqYmBIUlqYmBIkpoYGJKkJgaGJKmJgSFJamJgSJKaGBiSpCYGhiSpiYEhSWpiYEiS\nmhgYkqQmBoYkqYmBIUlqYmBIkpoYGJKkJgaGJKmJgSFJajKRwEiyNcn+JA8n2T5i+5uTPJRkb5K7\nk7xgEu1KkqZn7MBIcgJwK3AVcCFwXZLNy6rdD2ypqouATwB/OW67kqTpmsQRxiXAwap6tKp+BOwC\nrh6uUFVfqKr/7Vb3AOdMoF1J0hRNIjDOAR4bWj/E6oHweuDOCbQrSZqiDRP4jIwoq5EVk9cCW4DL\nJtCuJGmKJhEYh4DzhtbPBb61vFKSK4Abgd/sTl2NtLS0dGS51+vR6/Um0EVJeu7o9/v0+/2pt5uq\nkQcD7R+QnAgcAC4Hvg3cC1xXVfuG6vw68DHgqqp6ZJXPqnH7I0mLJglVNepsz0SNfQ2jqp4B3gjs\nBh4CdlXVviRvS/Kqrto7gecBH0vyQJJPjtuuJGm6xj7CmCSPMCRp7dbNEYYkaTEYGJKkJgaGJKmJ\ngSFJamJgSJKaGBiSpCYGhiSpiYEhSWpiYEiSmhgYkqQmBoYkqYmBIUlqYmBIkpoYGJKkJgaGJKmJ\ngSFJamJgSJKaGBiSpCYGhiSpiYEhSWpiYEiSmhgYkqQmBoYkqcmGWXdgJUtL8IUvzLoXkqRnpapm\n3YcjktSz/fnKV+CJJ2bcIUlaB17xilBVOd7tzG1gSJLaJNMJDK9hSJKaGBiSpCYGhiSpiYEhSWpi\nYEiSmhgYkqQmBoYkqYmBIUlqYmBIkpoYGJKkJhMJjCRbk+xP8nCS7SO2n5xkV5KDSb6Y5LxJtCtJ\nmp6xAyPJCcCtwFXAhcB1STYvq/Z64Kmq+iXgFuCd47YrSZquSRxhXAIcrKpHq+pHwC7g6mV1rgZu\n65Y/Dlw+gXYlSVM0icA4B3hsaP1QVzayTlU9Azyd5IwJtC1JmpJJPEBp1L/UXf4/ypfXyYg6ACwt\nLR1Z7vV69Hq9MbomSc89/X6ffr8/9XbHfh5GkkuBpara2q3vAKqqdg7VubOr86UkJwLfrqqzRnyW\nz8OQpDVaT8/DuA+4IMkLk5wMXAvcsazOvwHbuuVrgHsm0K4kaYrGPiVVVc8keSOwm0EAfaCq9iV5\nG3BfVX0K+ADwoSQHgScZhIokaR3xEa2StM6tp1NSkqQFYGBIkpoYGJKkJgaGJKmJgSFJamJgSJKa\nGBiSpCYGhiSpiYEhSWpiYEiSmhgYkqQmBoYkqYmBIUlqYmBIkpoYGJKkJgaGJKmJgSFJamJgSJKa\nGBiSpCYGhiSpiYEhSWpiYEiSmhgYkqQmBoYkqYmBIUlqYmBIkpoYGJKkJgaGJKmJgSFJamJgSJKa\nGBiSpCYGhiSpiYEhSWpiYEiSmhgYkqQmYwVGko1Jdic5kOSuJKeNqPOSJP+e5MtJ9ib5/XHalCTN\nRqrqp39zshN4sqremWQ7sLGqdiyrcwFQVfVIkl8E/hPYXFXfH/F5NU5/JGkRJaGqctzbGTMw9gOX\nVdXhJJuAflVtPsZ79gK/W1WPjNhmYEjSGk0rMMa9hnFWVR0GqKrHgTNXq5zkEuCkUWEhSZpvG45V\nIcndwNnDRUABb11LQ93pqH8A/nAt75MkzYdjBkZVXbnStiSHk5w9dErqOyvUOxX4FHBTVd23WntL\nS0tHlnu9Hr1e71hdlKSF0u/36ff7U293Ehe9n6qqnatc9D4J+Cxwe1W95xif5zUMSVqj9XLR+wzg\no8ALgG8A11TV00m2AG+oqj9K8gfAB4GHOHo664aqenDE5xkYkrRG6yIwJs3AkKS1Wy93SUmSFoSB\nIUlqYmBIkpoYGJKkJgaGJKmJgSFJamJgSJKaGBiSpCYGhiSpiYEhSWpiYEiSmhgYkqQmBoYkqYmB\nIUlqYmBIkpoYGJKkJgaGJKmJgSFJamJgSJKaGBiSpCYGhiSpiYEhSWpiYEiSmhgYkqQmBoYkqYmB\nIUlqYmBIkpoYGJKkJgaGJKmJgSFJamJgSJKaGBiSpCYGhiSpiYEhSWpiYEiSmhgYkqQmYwVGko1J\ndic5kOSuJKetUvfUJIeSvGecNiVJszHuEcYO4HNV9SvAPcCNq9R9O9Afsz1J0oyMGxhXA7d1y7cB\nvzOqUpItwFnA7jHbkyTNyLiBcVZVHQaoqseBM5dXSBLgr4C3ABmzPUnSjGw4VoUkdwNnDxcBBby1\nsY0/AT5dVd8cZMfqobG0tHRkudfr0ev1GpuRpMXQ7/fp9/tTbzdV9dO/OdkH9KrqcJJNwOer6leX\n1fkw8HLgx8CpwEnAe6vqphGfV+P0R5IWURKq6rifwRk3MHYCT1XVziTbgY1VtWOV+tuALVX1phW2\nGxiStEbTCoxxr2HsBK5McgC4AngHDC5yJ3n/uJ2TJM2PsY4wJs0jDElau/VyhCFJWhAGhiSpiYEh\nSWpiYEiSmhgYkqQmBoYkqYmBIUlqYmBIkpoYGJKkJgaGJKmJgSFJamJgSJKaGBiSpCYGhiSpiYEx\np2bx+MV55Vgc5Vgc5VhMn4Exp/xhOMqxOMqxOMqxmD4DQ5LUxMCQJDWZu0e0zroPkrQeTeMRrXMV\nGJKk+eUpKUlSEwNDktRkbgIjydYk+5M8nGT7rPszCUnOTXJPkq8m+XKSN3XlG5PsTnIgyV1JTht6\nz3uSHEyyN8lFQ+XburE5kOT6ofKLkzzYbbtlunu4dklOSHJ/kju69fOT7On26yNJNnTlJyfZ1Y3F\nF5OcN/QZN3bl+5K8cqh83cyhJKcl+Vi3Dw8leemizoskb07yla6//9h99wszL5J8IMnhJA8OlR33\nubBaGyuqqpm/GATX14AXAicBe4HNs+7XBPZrE3BRt3wKcADYDOwE/qIr3w68o1v+LeDT3fJLgT3d\n8kbgEeA04PRnl7ttXwIu6ZY/A1w16/0+xpi8GfgwcEe3/s/ANd3y+4A3dMt/DLy3W34NsKtb/jXg\nAWADcH43b7Le5hDw98DruuUN3Xe7cPMCeD7wdeDkofmwbZHmBfBy4CLgwaGy4z4XVmpj1b7OerC6\nzl4K3Dm0vgPYPut+HYf9/CRwBbAfOLsr2wTs65b/FnjNUP19wNnAtcD7hsrf1/2wbAK+OlT+E/Xm\n7QWcC9wN9DgaGE8AJyyfB8BngZd2yycC3xk1N4A7ux+cdTOHgFOBR0aUL9y8YBAYj3a/8DYAdwBX\nAt9ZpHnBINCGA+O4z4URbew/Vj/n5ZTUOcBjQ+uHurLnjCTnM/grYg+DL+kwQFU9DpzVVVtpHJaX\nf3Oo/NCI+vPqXcBbgAJI8gvAd6vqx9324f4f2eeqegb4XpIzWH0s1sscejHw30n+rjs99/4kP8cC\nzouq+hbw18A3GPT/e8D9wNMLOC+GnTWFubB8vp15rE7NS2CMun/4OXO/b5JTgI8Df1ZVP2DlfVs+\nDunqrjQ+62bckvw2cLiq9nK03+H/70MNbVvuOTEWDP6Svhj4m6q6GPgfBn/5LuK8OB24msFf2M8H\nnsfgtMtyizAvWsx0LsxLYBwCzhtaPxf41oz6MlHdxbqPAx+qqtu74sNJzu62b2Jw+A2DcXjB0Nuf\nHYeVxmel+vPoZcCrk3wd+AjwCuAW4LQkz87D4f4f2bckJzI4H/td1j5G8+gQ8FhV/Ue3/gkGAbKI\n8+IK4OtV9VR3xPCvwG8Apy/gvBg2jbnw+AptrGheAuM+4IIkL0xyMoPzbHfMuE+T8kEG5xDfPVR2\nB3BDt3wDcPtQ+fUASS5lcFh+GLgLuLK7s2Yjg3O8d3WHkd9PckmSdO+9nTlUVTdV1XlV9WIG3+89\nVfVa4PPANV21bfzkWGzrlq8B7hkqv7a7W+ZFwAXAvayjOdR9p48l+eWu6HLgIRZwXjA4FXVpkp/t\n+vrsWCzavFh+tD2NuTDcxvAYr2zWF3uGLsZsZXAX0UFgx6z7M6F9ehnwDIM7Mx5gcG52K3AG8Llu\nf+8GTh96z60M7ur4L+DiofIburF5GLh+qHwL8OVu27tnvc+N43IZRy96v4jBXRwPM7gz5qSu/GeA\nj3b7tQc4f+j9N3ZjtA945XqcQ8BLGPwy2wv8C4O7WxZyXgA3d9/lg8BtDO5mWph5AfwTg7/6f8gg\nQF/H4CaA4zoXVptvK7381yCSpCbzckpKkjTnDAxJUhMDQ5LUxMCQJDUxMCRJTQwMSVITA0OS1MTA\nkCQ1+T8oQkpyiwXK4wAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<matplotlib.figure.Figure at 0x7fad7f7b9590>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "plt.plot(gross_wage[1:], 1 - marginal_rate(-csg, gross_wage))\n",
     "plt.ylim(-0.5,0.5)"
@@ -521,9 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -531,23 +264,23 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/notebooks/requirements.txt
+++ b/notebooks/requirements.txt
@@ -1,0 +1,5 @@
+ipykernel >= 4.8
+jupyter-client >= 5.2
+nbconvert >= 5.3
+nbformat >= 4.4
+OpenFisca-France >= 22.0.0, < 23.0

--- a/notebooks/requirements.txt
+++ b/notebooks/requirements.txt
@@ -2,4 +2,5 @@ ipykernel >= 4.8
 jupyter-client >= 5.2
 nbconvert >= 5.3
 nbformat >= 4.4
-OpenFisca-France >= 22.0.0, < 23.0
+matplotlib >= 2.2
+OpenFisca-France >= 29.0.0, < 30.0

--- a/notebooks/test_notebooks.py
+++ b/notebooks/test_notebooks.py
@@ -6,7 +6,6 @@ from io import open
 
 from nbformat import read, write
 from nbconvert.preprocessors import ExecutePreprocessor, CellExecutionError
-# Other dependencies: jupyter-client, ipykernel
 
 import logging
 import traceback
@@ -16,10 +15,12 @@ import traceback
 Checks notebooks by trying to convert each one of them into a notebook that
 includes the execution results.
 
-This script is similar to this command:
-
+This script is similar to running this command:
     jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=60 \
                       --output executed_notebook.ipynotebook demo.ipynb
+
+on a group of notebooks. Whenever an error occurs, this script will give the user
+pretty printed output in order to fix it.
 '''
 
 

--- a/notebooks/test_notebooks.py
+++ b/notebooks/test_notebooks.py
@@ -1,23 +1,25 @@
 # -*- coding: utf-8 -*-
 
-
-'''
-Checks notebook execution result.
-Equal to this command + error management:
-jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=60 --output executed_notebook.ipynb demo.ipynb
-
-For nbconvert information, see: http://nbconvert.readthedocs.io/en/latest/index.html
-For jupyter configuration information, run: jupyter --path
-'''
-
-# Dependencies: nbformat, nbconvert, jupyter-client, ipykernel
-import io
-import nbformat
-from nbconvert.preprocessors import ExecutePreprocessor, CellExecutionError
 import sys
 import os
+from io import open
+
+from nbformat import read, write
+from nbconvert.preprocessors import ExecutePreprocessor, CellExecutionError
+# Other dependencies: jupyter-client, ipykernel
+
 import logging
 import traceback
+
+
+'''
+Checks notebooks by trying to convert each one into a notebook
+that includes its execution results.
+
+This script is similar to this command:
+jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=60
+                  --output executed_notebook.ipynotebook demo.ipynb
+'''
 
 
 log = logging.getLogger(__name__)
@@ -26,61 +28,71 @@ log.setLevel(logging.DEBUG)
 
 
 def is_notebook(file_path):
-  return file_path[-6:] == ".ipynb"
+    return file_path[-6:] == ".ipynb"
 
 
 def run(notebook_path):
-    directory = os.path.dirname(notebook_path)
-    run_path = directory
+    '''
+    Test given notebook execution.
+    If an error occurs, save execution result in a new notebook 
+    of same name with 'executed_' prefix.
+    '''
+    notebook_directory = os.path.dirname(notebook_path)
     notebook_filename = os.path.basename(notebook_path)
-    notebook_filename_out = os.path.join(directory, 'executed_' + notebook_filename)
+    notebook_filename_out = os.path.join(
+        notebook_directory,
+        'executed_' + notebook_filename
+        )
 
-    with io.open(notebook_path) as f:
-        nb = nbformat.read(f, as_version=4)
+    with open(notebook_path) as f:
+        notebook = read(f, as_version=4)
 
-    ep = ExecutePreprocessor(timeout=600, kernel_name='python')
-    error = False
     try:
-        out = ep.preprocess(nb, {'metadata': {'path': run_path}})
+        # Execute all the cells in the notebook
+        ep = ExecutePreprocessor(timeout=600, kernel_name='python')
+        executed_notebook = ep.preprocess(notebook,
+                {'metadata': {'path': notebook_directory}}
+                )
+
     except CellExecutionError:
-        error = True
-        out = None
+        executed_notebook = None
         msg = 'Error executing the notebook "%s".\n\n' % notebook_filename
-        msg += 'See notebook "%s" for the traceback.' % notebook_filename_out
+        msg += 'See notebook "%s" for traceback.' % notebook_filename_out
         log.error(msg)
         raise
+
     finally:
-        with io.open(notebook_filename_out, mode='wt') as f:  # io.open avoids UnicodeEncodeError
-            nbformat.write(nb, f)
+        with open(notebook_filename_out, mode='wt') as f:
+            write(notebook, f)
+        if executed_notebook is not None:
+            os.remove(notebook_filename_out)
 
-    if not error:
-        os.remove(notebook_filename_out)
 
-
+# Check script target (file or directory) and test all notebooks
 if __name__ == "__main__":
-  try:
-    target = sys.argv[1]
+    try:
+        target = sys.argv[1]
 
-    if os.path.isdir(target):
-      for file in os.listdir(target):
-        if is_notebook(file):
-          log.debug("> " + file)
-          run(os.path.join(target, file))
-    else:
-        if not is_notebook(target):
-            raise Exception(u"Expected an .ipynb file. Got: {}".format(target))
-        run(target)
+        if os.path.isdir(target):
+            for file in os.listdir(target):
+                if is_notebook(file):
+                    log.debug("> " + file)
+                    run(os.path.join(target, file))
+        else:
+            if not is_notebook(target):
+                raise Exception(u"Expected an .ipynb file. Got: {}".format(target))
+            run(target)
 
-  except BaseException as e:
-    if len(sys.argv) == 1:
-      log.error(u"Missing a directory or a notebook to test.")
-      log.warn(u"USAGE : python test_notebooks.py target")
-      log.warn(u"        where 'target' is a directory containing .ipynb file OR an .ipynb file to test.")
-    else:
-      log.debug(str(e.__class__.__name__)+ ': ')
-      if e.__class__.__name__ is "CellExecutionError" and e.from_cell_and_msg:
-        log.debug(e.from_cell_and_msg)
-      elif e.message:
-        log.debug(e.message)
-      
-      log.error(traceback.format_exc())
+    except BaseException as e:
+        if len(sys.argv) == 1:
+            log.error(u"Missing a notebook directory or a notebook to test.")
+            log.warn(u"USAGE: python test_notebooks.py target")
+            log.warn(u"where 'target' is a notebooks directory OR an .ipynb notebook file to test.")
+
+        else:
+            log.debug(str(e.__class__.__name__) + ': ')
+            if e.__class__ is CellExecutionError and e.from_cell_and_msg:
+                log.debug(e.from_cell_and_msg)
+            elif e.message:
+                log.debug(e.message)
+            log.error(traceback.format_exc())

--- a/notebooks/test_notebooks.py
+++ b/notebooks/test_notebooks.py
@@ -13,12 +13,13 @@ import traceback
 
 
 '''
-Checks notebooks by trying to convert each one into a notebook
-that includes its execution results.
+Checks notebooks by trying to convert each one of them into a notebook that
+includes the execution results.
 
 This script is similar to this command:
-jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=60
-                  --output executed_notebook.ipynotebook demo.ipynb
+
+    jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=60 \
+                      --output executed_notebook.ipynotebook demo.ipynb
 '''
 
 
@@ -33,9 +34,10 @@ def is_notebook(file_path):
 
 def run(notebook_path):
     '''
-    Test given notebook execution.
-    If an error occurs, save execution result in a new notebook 
-    of same name with 'executed_' prefix.
+    Execute a notebook.
+
+    If an error occurs, then save results in a new notebook
+    of the name, prefixed bt "executed_".
     '''
     notebook_directory = os.path.dirname(notebook_path)
     notebook_filename = os.path.basename(notebook_path)
@@ -45,24 +47,25 @@ def run(notebook_path):
         )
 
     with open(notebook_path) as f:
-        notebook = read(f, as_version=4)
+        notebook = read(f, as_version = 4)
 
     try:
         # Execute all the cells in the notebook
-        ep = ExecutePreprocessor(timeout=600, kernel_name='python')
-        executed_notebook = ep.preprocess(notebook,
-                {'metadata': {'path': notebook_directory}}
-                )
+        ep = ExecutePreprocessor(timeout = 600, kernel_name = "python")
+        executed_notebook = ep.preprocess(
+            notebook,
+            {"metadata": {"path": notebook_directory}}
+            )
 
     except CellExecutionError:
         executed_notebook = None
         msg = 'Error executing the notebook "%s".\n\n' % notebook_filename
-        msg += 'See notebook "%s" for traceback.' % notebook_filename_out
+        msg += 'See notebook "%s" for stack traceback.' % notebook_filename_out
         log.error(msg)
         raise
 
     finally:
-        with open(notebook_filename_out, mode='wt') as f:
+        with open(notebook_filename_out, mode = "wt") as f:
             write(notebook, f)
         if executed_notebook is not None:
             os.remove(notebook_filename_out)
@@ -85,12 +88,12 @@ if __name__ == "__main__":
 
     except BaseException as e:
         if len(sys.argv) == 1:
-            log.error(u"Missing a notebook directory or a notebook to test.")
+            log.error(u"Missing notebook or directory containing notebooks to test.")
             log.warn(u"USAGE: python test_notebooks.py target")
-            log.warn(u"where 'target' is a notebooks directory OR an .ipynb notebook file to test.")
+            log.warn(u"where 'target' is directory containing notebooks, or a .ipynb notebook file.")
 
         else:
-            log.debug(str(e.__class__.__name__) + ': ')
+            log.debug(str(e.__class__.__name__) + ": ")
             if e.__class__ is CellExecutionError and e.from_cell_and_msg:
                 log.debug(e.from_cell_and_msg)
             elif e.message:

--- a/notebooks/test_notebooks.py
+++ b/notebooks/test_notebooks.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+
+
+'''
+Checks notebook execution result.
+Equal to this command + error management:
+jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=60 --output executed_notebook.ipynb demo.ipynb
+
+For nbconvert information, see: http://nbconvert.readthedocs.io/en/latest/index.html
+For jupyter configuration information, run: jupyter --path
+'''
+
+# Dependencies: nbformat, nbconvert, jupyter-client, ipykernel
+import io
+import nbformat
+from nbconvert.preprocessors import ExecutePreprocessor, CellExecutionError
+import sys
+import os
+import logging
+import traceback
+
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.StreamHandler())
+log.setLevel(logging.DEBUG)
+
+
+def is_notebook(file_path):
+  return file_path[-6:] == ".ipynb"
+
+
+def run(notebook_path):
+    directory = os.path.dirname(notebook_path)
+    run_path = directory
+    notebook_filename = os.path.basename(notebook_path)
+    notebook_filename_out = os.path.join(directory, 'executed_' + notebook_filename)
+
+    with io.open(notebook_path) as f:
+        nb = nbformat.read(f, as_version=4)
+
+    ep = ExecutePreprocessor(timeout=600, kernel_name='python')
+    error = False
+    try:
+        out = ep.preprocess(nb, {'metadata': {'path': run_path}})
+    except CellExecutionError:
+        error = True
+        out = None
+        msg = 'Error executing the notebook "%s".\n\n' % notebook_filename
+        msg += 'See notebook "%s" for the traceback.' % notebook_filename_out
+        log.error(msg)
+        raise
+    finally:
+        with io.open(notebook_filename_out, mode='wt') as f:  # io.open avoids UnicodeEncodeError
+            nbformat.write(nb, f)
+
+    if not error:
+        os.remove(notebook_filename_out)
+
+
+if __name__ == "__main__":
+  try:
+    target = sys.argv[1]
+
+    if os.path.isdir(target):
+      for file in os.listdir(target):
+        if is_notebook(file):
+          log.debug("> " + file)
+          run(os.path.join(target, file))
+    else:
+        if not is_notebook(target):
+            raise Exception(u"Expected an .ipynb file. Got: {}".format(target))
+        run(target)
+
+  except BaseException as e:
+    if len(sys.argv) == 1:
+      log.error(u"Missing a directory or a notebook to test.")
+      log.warn(u"USAGE : python test_notebooks.py target")
+      log.warn(u"        where 'target' is a directory containing .ipynb file OR an .ipynb file to test.")
+    else:
+      log.debug(str(e.__class__.__name__)+ ': ')
+      if e.__class__.__name__ is "CellExecutionError" and e.from_cell_and_msg:
+        log.debug(e.from_cell_and_msg)
+      elif e.message:
+        log.debug(e.message)
+      
+      log.error(traceback.format_exc())


### PR DESCRIPTION
Connected to #37 

* In order to check notebooks statuses at OpenFisca evolutions, this starts by scripting notebooks checks for a specific version of OpenFisca (aka `openfisca-france` here).
* Details: 
  * Adds `test_notebooks.py` script to automatically check existing notebooks execution
  * Adds a list of all notebooks dependencies in `requirements.txt`
  * Adds a `Makefile` to allow easy install, execution and cleaning.