### PR TITLE
Fix notebooks tests in CI and simplify CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,30 +12,21 @@ jobs:
           path: ~/tutorial
 
       - restore_cache:
-          key: v2-{{ checksum "Pipfile.lock" }}
-
-      - run:
-          name: Create a virtualenv
-          command: |
-            mkdir -p venv
-            python -m venv venv
+          key: v3-{{ checksum "Pipfile.lock" }}
 
       - run:
           name: Install dependencies
-          command: |
-            source venv/bin/activate
-            make install
+          command: make install
 
       - run:
           name: Test notebooks
-          command: |
-            source venv/bin/activate
-            make test
+          command: make test
 
       - save_cache:
-          key: v2-{{ checksum "Pipfile.lock" }}
+          key: v3-{{ checksum "Pipfile.lock" }}
           paths:
-            - venv
+            - ~/.local/share/virtualenvs
+            - ./venv
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
 
       - run:
           name: Test notebooks
-          command:
+          command: |
             source venv/bin/activate
             make test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,6 @@ jobs:
       - checkout:
           path: ~/tutorial
 
-      - restore_cache:
-          key: v3-{{ checksum "Pipfile.lock" }}
-
       - run:
           name: Install dependencies
           command: make install
@@ -21,12 +18,6 @@ jobs:
       - run:
           name: Test notebooks
           command: make test
-
-      - save_cache:
-          key: v3-{{ checksum "Pipfile.lock" }}
-          paths:
-            - ~/.local/share/virtualenvs
-            - ./venv
 
 workflows:
   version: 2


### PR DESCRIPTION
Connected to #37 

* Fix Circle CI `Test notebooks` step (missing new line between commands)
* Remove cache management as there is no significant impact on build time and there is uncertainty on where `pipenv` stores installed libraries and how it interacts with `venv`.
 