### PR TITLE
CircleCI should fail in case of error

### DIFF
--- a/notebooks/test_notebooks.py
+++ b/notebooks/test_notebooks.py
@@ -65,7 +65,7 @@ def run(notebook_path):
 
     except CellExecutionError:
         msg = 'Error executing the notebook "%s".\n' % notebook_filename
-        msg += 'See notebook "%s" for stack traceback.\n' % notebook_filename_out
+        msg += 'Take a look at the stack trace for more information.\n'
         log.error(msg)
         raise
 

--- a/notebooks/test_notebooks.py
+++ b/notebooks/test_notebooks.py
@@ -53,23 +53,21 @@ def run(notebook_path):
     try:
         # Execute all the cells in the notebook
         ep = ExecutePreprocessor(timeout = 600, kernel_name = "python")
-        executed_notebook = ep.preprocess(
+        ep.preprocess(
             notebook,
             {"metadata": {"path": notebook_directory}}
             )
 
+        with open(notebook_filename_out, mode = "wt") as f:
+            write(notebook, f)
+
+        os.remove(notebook_filename_out)
+
     except CellExecutionError:
-        executed_notebook = None
         msg = 'Error executing the notebook "%s".\n' % notebook_filename
         msg += 'See notebook "%s" for stack traceback.\n' % notebook_filename_out
         log.error(msg)
         raise
-
-    finally:
-        with open(notebook_filename_out, mode = "wt") as f:
-            write(notebook, f)
-        if executed_notebook is not None:
-            os.remove(notebook_filename_out)
 
 
 # Check script target (file or directory) and test all notebooks
@@ -101,3 +99,4 @@ if __name__ == "__main__":
             elif e.message:
                 log.debug(e.message)
             log.error(traceback.format_exc())
+            sys.exit(1)


### PR DESCRIPTION
Connected to #37 

In this example, removing `matplotlib`.

~~(il ne faut pas merger toute de suite, seulement dire si vous approuvez ou pas).~~ Reverted.