### PR TITLE
Save notebooks execution results on GitHub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,24 @@ jobs:
     steps:
       - checkout
 
+      - restore_cache:
+          key: v1-py3-{{ .Branch }}-{{ checksum "setup.py" }}
+
+      - run:
+          name: Create a virtualenv
+          command: |
+            mkdir -p /tmp/venv/tutorial
+            python -m venv /tmp/venv/tutorial
+            echo "source /tmp/venv/tutorial/bin/activate" >> $BASH_ENV
+
       - run:
           name: Install dependencies
           command: make install
+
+      - save_cache:
+          key: v1-py3-{{ .Branch }}-{{ checksum "setup.py" }}
+          paths:
+            - /tmp/venv/tutorial
 
       - run:
           name: Test notebooks
@@ -17,8 +32,38 @@ jobs:
             cd notebooks
             make test
 
+  save_notebooks:
+    docker:
+      - image: python:3.7
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: v1-py3-{{ .Branch }}-{{ checksum "setup.py" }}
+
+      - run:
+          name: Test notebooks
+          command: |
+            cd notebooks
+            make test
+
+      - run:
+          name: Commit notebooks updated by tests
+          command: |
+            git add .
+            git commit -m "Save notebooks execution results"
+            git push
+
+
 workflows:
   version: 2
-  build:
+  build_and_save_notebooks:
     jobs:
       - build
+      - save_notebooks:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 .RData
 .Rhistory
 notebooks/.ipynb_checkpoints
-notebooks/executed_*

--- a/notebooks/test_notebooks.py
+++ b/notebooks/test_notebooks.py
@@ -35,17 +35,10 @@ def is_notebook(file_path):
 
 def run(notebook_path):
     '''
-    Execute a notebook.
-
-    If an error occurs, then save results in a new notebook
-    of the name, prefixed bt "executed_".
+    Execute a notebook and update it with its execution result.
     '''
     notebook_directory = os.path.dirname(notebook_path)
     notebook_filename = os.path.basename(notebook_path)
-    notebook_filename_out = os.path.join(
-        notebook_directory,
-        'executed_' + notebook_filename
-        )
 
     with open(notebook_path) as f:
         notebook = read(f, as_version = 4)
@@ -58,16 +51,15 @@ def run(notebook_path):
             {"metadata": {"path": notebook_directory}}
             )
 
-        with open(notebook_filename_out, mode = "wt") as f:
-            write(notebook, f)
-
-        os.remove(notebook_filename_out)
-
     except CellExecutionError:
         msg = 'Error executing the notebook "%s".\n' % notebook_filename
         msg += 'Take a look at the stack trace for more information.\n'
         log.error(msg)
         raise
+
+    finally:
+	    with open(notebook_path, mode = "wt") as f:
+	        write(notebook, f)
 
 
 # Check script target (file or directory) and test all notebooks

--- a/notebooks/test_notebooks.py
+++ b/notebooks/test_notebooks.py
@@ -17,7 +17,8 @@ includes the execution results.
 
 This script is similar to running this command:
     jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=60 \
-                      --output executed_notebook.ipynotebook demo.ipynb
+                      --ExecutePreprocessor.kernel_name=python3 \
+                      --output demo.ipynb demo.ipynb
 
 on a group of notebooks. Whenever an error occurs, this script will give the user
 pretty printed output in order to fix it.
@@ -45,7 +46,7 @@ def run(notebook_path):
 
     try:
         # Execute all the cells in the notebook
-        ep = ExecutePreprocessor(timeout = 600, kernel_name = "python")
+        ep = ExecutePreprocessor(timeout = 600, kernel_name = "python3")
         ep.preprocess(
             notebook,
             {"metadata": {"path": notebook_directory}}


### PR DESCRIPTION
Connected to #37 
Cette PR répond en particulier à [ce dernier commentaire](https://github.com/openfisca/tutorial/issues/37#issuecomment-458588522).
> Objet : Mémoriser le résultat d'exécution des notebooks sur les PR des contributeurs et de `dependabot`. 

* Met à jour les notebooks avec leurs résultats d'exécution lorsqu'ils sont exécutés via `make test` (ou `test_notebooks.py`)
* Commit le résultat de l'exécution des notebooks sur GitHub
  * Le résultat commité est le dernier disponible avant merge sur la branche `master`
  > Avantage : Les résultats d'exécution peuvent contenir des informations sur des chemins de fichiers (en particulier pour les warnings). En commitant la version exécutée sur CircleCI, on évite les chemins de fichiers spécifiques aux installations locales des contributeurs.




