### PR TITLE
Activate virtualenv on master to access installed libraries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,11 @@ jobs:
           key: v1-py3-{{ .Branch }}-{{ checksum "requirements.txt" }}
 
       - run:
+          name: Activate virtualenv
+          command: |
+            echo "source /tmp/venv/tutorial/bin/activate" >> $BASH_ENV
+
+      - run:
           name: Test notebooks
           command: |
             cd notebooks


### PR DESCRIPTION
Connected to #74 

Enable tests on master branch to access cache libraries (installed in a virtual environment).