### PR TITLE
Fix notebooks configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             git config user.name "openfisca-bot" 
             git add .
             git commit -m "Save notebooks execution results"
-            git push
+            git push --set-upstream origin `git name-rev --name-only HEAD`
 
 workflows:
   version: 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ jupyter==1.0.0
 matplotlib==3.0.3
 nbconvert==5.4.1
 nbformat==4.4.0
-numpy==1.16.2
+numpy<1.16,>=1.11
 openfisca-france==37.0.0


### PR DESCRIPTION
Fixes errors detected by [this CI build](https://circleci.com/gh/openfisca/tutorial/155).

* On step `Install dependencies`, fixes `numpy` library dependency
  * Fixed issue message:
     ```
     openfisca-core 26.2.0 has requirement numpy<1.16,>=1.11, but you'll have numpy 1.16.2 which is    
     incompatible.
     ```
* On step `Commit notebooks updated by tests`, sets upstream branch name
  * Fixed issue message:
     ```
     $ git push
     [dependabot/pip/openfisca-france-38.1.1 1eaf7f1] Save notebooks execution results
     5 files changed, 31 insertions(+), 40 deletions(-)
     fatal: The current branch dependabot/pip/openfisca-france-38.1.1 has no upstream branch.
     To push the current branch and set the remote as upstream, use

     git push --set-upstream origin dependabot/pip/openfisca-france-38.1.1
     ```
     > The solution worked on this [CI build](https://circleci.com/gh/openfisca/tutorial/158) (tested manually after ssh connection on the build)